### PR TITLE
generate_random_observable now returns object

### DIFF
--- a/src/cppsim/utility.cpp
+++ b/src/cppsim/utility.cpp
@@ -30,10 +30,10 @@ void get_Pauli_matrix(
         matrix(index, index ^ flip_mask) = rot[rot90_count % 4] * sign;
     }
 }
-/*
-Observable* generate_random_observable(
+
+Observable generate_random_observable(
     const UINT qubit_count, const UINT operator_count) {
-    Observable* observable = new Observable(qubit_count);
+    auto observable = Observable(qubit_count);
     Random random;
     for (auto operator_index = 0; operator_index < operator_count;
          operator_index++) {
@@ -47,11 +47,11 @@ Observable* generate_random_observable(
         CPPCTYPE coef = random.uniform();
         auto pauli_operator = PauliOperator(
             target_qubit_index_list, target_qubit_pauli_list, coef);
-        observable->add_operator(&pauli_operator);
+        observable.add_operator(&pauli_operator);
     }
     return observable;
 }
-*/
+
 ComplexMatrix convert_observable_to_matrix(const Observable* observable) {
     const auto dim = observable->get_state_dim();
     const auto qubit_count = observable->get_qubit_count();

--- a/src/cppsim/utility.hpp
+++ b/src/cppsim/utility.hpp
@@ -51,10 +51,9 @@ void DllExport get_Pauli_matrix(
  * @return ランダムなパウリ演算子をもつ operator を operator_count 個もつ
  * observable
  */
-/*
-Observable* DllExport generate_random_observable(
+Observable DllExport generate_random_observable(
     const UINT qubit_count, const UINT operator_count);
-*/
+
 /**
  * \~japanese-en
  * observable を対応する行列に変換する


### PR DESCRIPTION
Build on Windows failed because `Observable* DllExport generate_random_observable()` was invalid. I fixed it to return `Observable`, not a pointer.