### PR TITLE
fix warning

### DIFF
--- a/benchmark/causalconetest.cpp
+++ b/benchmark/causalconetest.cpp
@@ -31,7 +31,7 @@ int main() {
     }
     Observable observable(n * 2);
     mt19937 rnd(chrono::steady_clock::now().time_since_epoch().count());
-    for (int i = 0; i < n * 2; ++i) {
+    for (int i = 0; i < (int)n * 2; ++i) {
         std::string s = "Z ";
         s += std::to_string(i);
         observable.add_operator(rnd(), s);

--- a/src/vqcsim/causalcone_simulator.hpp
+++ b/src/vqcsim/causalcone_simulator.hpp
@@ -101,13 +101,15 @@ public:
                         use_qubit[control_index] = true;
                     }
 
-                    for (UINT i = 0; i + 1 < target_index_list.size(); i++) {
+                    for (UINT j = 0; j + 1 < (UINT)target_index_list.size();
+                         j++) {
                         uf.connect(
-                            target_index_list[i], target_index_list[i + 1]);
+                            target_index_list[j], target_index_list[j + 1]);
                     }
-                    for (UINT i = 0; i + 1 < control_index_list.size(); i++) {
+                    for (UINT j = 0; j + 1 < (UINT)control_index_list.size();
+                         j++) {
                         uf.connect(
-                            control_index_list[i], control_index_list[i + 1]);
+                            control_index_list[j], control_index_list[j + 1]);
                     }
                     if (!target_index_list.empty() &&
                         !control_index_list.empty()) {
@@ -122,7 +124,7 @@ public:
             UINT circuit_count = 0;
             std::vector<UINT> roots;
             for (UINT i = 0; i < qubit_count; i++) {
-                if (use_qubit[i] && i == uf.root(i)) {
+                if (use_qubit[i] && i == (UINT)uf.root(i)) {
                     roots.emplace_back(uf.root(i));
                     circuit_count += 1;
                 }
@@ -139,31 +141,32 @@ public:
                 std::vector<int> qubit_encode(qubit_count, -1);
 
                 int idx = 0;
-                for (UINT i = 0; i < qubit_count; i++) {
-                    if (root == uf.root(i)) {
-                        qubit_encode[i] = idx++;
+                for (UINT j = 0; j < (UINT)qubit_count; j++) {
+                    if (root == (UINT)uf.root(j)) {
+                        qubit_encode[j] = idx++;
                     }
                 }
 
-                for (UINT i = 0; i < gate_count; i++) {
-                    if (!use_gate[i]) continue;
+                for (UINT j = 0; j < gate_count; j++) {
+                    if (!use_gate[j]) continue;
 
-                    auto gate = init_circuit->gate_list[i]->copy();
+                    auto gate = init_circuit->gate_list[j]->copy();
                     auto target_index_list = gate->get_target_index_list();
                     auto control_index_list = gate->get_control_index_list();
-                    if (uf.root(target_index_list[0]) != root) continue;
-                    for (auto& idx : target_index_list) idx = qubit_encode[idx];
-                    for (auto& idx : control_index_list)
-                        idx = qubit_encode[idx];
+                    if ((UINT)uf.root(target_index_list[0]) != root) continue;
+                    for (auto& target_idx : target_index_list)
+                        target_idx = qubit_encode[target_idx];
+                    for (auto& control_idx : control_index_list)
+                        control_idx = qubit_encode[control_idx];
 
                     gate->set_target_index_list(target_index_list);
                     gate->set_control_index_list(control_index_list);
                     circuit->add_gate(gate);
                 }
                 auto& paulioperator = pauli_operators[i];
-                for (UINT i = 0; i < (UINT)term_index_list.size(); i++) {
+                for (UINT j = 0; j < (UINT)term_index_list.size(); j++) {
                     paulioperator.add_single_Pauli(
-                        qubit_encode[term_index_list[i]], pauli_id_list[i]);
+                        qubit_encode[term_index_list[j]], pauli_id_list[j]);
                 }
             }
             circuit_list.emplace_back(circuits);
@@ -180,9 +183,9 @@ public:
             auto& circuits = circuit_list[i];
             auto& pauli_operators = pauli_operator_list[i];
             auto& coef = coef_list[i];
-            for (UINT i = 0; i < (UINT)circuits.size(); i++) {
-                auto& circuit = circuits[i];
-                auto& paulioperator = pauli_operators[i];
+            for (UINT j = 0; j < (UINT)circuits.size(); j++) {
+                auto& circuit = circuits[j];
+                auto& paulioperator = pauli_operators[j];
                 QuantumState state(circuit->qubit_count);
                 state.set_zero_state();
                 circuit->update_quantum_state(&state);


### PR DESCRIPTION
Warningまわりを減らしました．

C++のコンパイルオプションでついたwarningはほぼ消えてると思います．

@kotamanegi cppsim_experimetal/noisesimulator.cpp の 54行目のfor分の未使用に関しては[[maybe_unused]]でごまかしています．