### PR TITLE
Run tests in CI parallelly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Ubuntu & Windows CI
 
 on:
   pull_request:
@@ -53,8 +53,8 @@ jobs:
       - name: Test in Ubuntu
         run: |
           cd ./build
-          make test
-          make pythontest
+          make test -j
+          make pythontest -j
         if: ${{ contains(matrix.os, 'ubuntu') }}
 
   nvcc-gcc8-GPUbuild:
@@ -94,8 +94,8 @@ jobs:
       - name: Test in Ubuntu
         run: |
           cd ./build
-          make test
-          make pythontest
+          make test -j
+          make pythontest -j
         if: ${{ contains(matrix.os, 'ubuntu') }}
 
   source-dist:

--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -1,4 +1,4 @@
-name: CI
+name: macOS CI
 
 on:
   push:
@@ -57,8 +57,8 @@ jobs:
       - name: Test in macOS
         run: |
           cd ./build
-          make test
-          make pythontest
+          make test -j
+          make pythontest -j
         if: ${{ contains(matrix.os, 'macos') }}
 
   wheel-build:

--- a/script/build_gcc.sh
+++ b/script/build_gcc.sh
@@ -30,6 +30,6 @@ mkdir ./build
 cd ./build
 cmake -G "Unix Makefiles" -D CMAKE_C_COMPILER=$GCC_COMMAND -D CMAKE_CXX_COMPILER=$GXX_COMMAND -D CMAKE_BUILD_TYPE=Release -D USE_GPU:STR=No -D USE_MPI:STR=No ..
 make -j
-make python
+make python -j
 cd ../
 

--- a/script/build_gcc_with_MPI.sh
+++ b/script/build_gcc_with_MPI.sh
@@ -30,6 +30,6 @@ mkdir ./build
 cd ./build
 cmake -G "Unix Makefiles" -D CMAKE_C_COMPILER=$GCC_COMMAND -D CMAKE_CXX_COMPILER=$GXX_COMMAND -D CMAKE_BUILD_TYPE=Release -D USE_GPU:STR=No -D USE_MPI:STR=Yes ..
 make -j
-make python
+make python -j
 cd ../
 

--- a/script/build_gcc_with_gpu.sh
+++ b/script/build_gcc_with_gpu.sh
@@ -17,6 +17,6 @@ mkdir ./build
 cd ./build
 cmake -G "Unix Makefiles" -D CMAKE_C_COMPILER=$GCC_COMMAND -D CMAKE_CXX_COMPILER=$GXX_COMMAND -D CMAKE_BUILD_TYPE=Release -D USE_GPU:STR=Yes -D USE_MPI:STR=No  ..
 make -j
-make python
+make python -j
 cd ../
 


### PR DESCRIPTION
CI のテストが並行に走るように `make test` などに `-j` フラグをつけました．
また，Windows/Ubuntu と macOS の CI の名前がどちらも "CI" で紛らわしかったので，適切な名前に変更しました．