### PR TITLE
nvcc test runs on `gpu` labeled runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,8 +62,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.7.5"]
-        os: ["ubuntu-self-hosted"]
-    runs-on: ${{ matrix.os }}
+    runs-on: ["gpu"]
     env:
       CXX_COMPILER: "g++-8"
       C_COMPILER: "gcc-8"


### PR DESCRIPTION
nvcc のテストが `gpu` のラベルがついた runner だけで動作するようになりました．