### PR TITLE
Delete lines overriding gcc

### DIFF
--- a/script/build_gcc.sh
+++ b/script/build_gcc.sh
@@ -1,30 +1,7 @@
 #!/bin/sh
 
-GCC_COMMAND="$C_COMPILER"
-GXX_COMMAND="$CXX_COMPILER"
-
-if [ -z "$GCC_COMMAND" ]; then
-  GCC_COMMAND="gcc"
-fi
-
-if [ -z "$GXX_COMMAND" ]; then
-  GXX_COMMAND="g++"
-fi
-
-# if gcc/g++ version is less than 8, use gcc-8/g++-8
-GCC_VERSION=$($GCC_COMMAND -dumpfullversion -dumpversion | awk -F. '{printf "%2d%02d%02d", $1,$2,$3}')
-if [ "$GCC_VERSION" -lt 80000 ]; then
-  GCC_COMMAND=gcc-7
-elif [ "$GCC_VERSION" -lt 90000 ]; then
-  GCC_COMMAND=gcc-8
-fi
-
-GXX_VERSION=$($GXX_COMMAND -dumpfullversion -dumpversion | awk -F. '{printf "%2d%02d%02d", $1,$2,$3}')
-if [ "$GXX_VERSION" -lt 80000 ]; then
-  GXX_COMMAND=g++-7
-elif [ "$GXX_VERSION" -lt 90000 ]; then
-  GXX_COMMAND=g++-8
-fi
+GCC_COMMAND=${C_COMPILER:-"gcc"}
+GXX_COMMAND=${CXX_COMPILER:-"g++"}
 
 mkdir ./build
 cd ./build
@@ -32,4 +9,3 @@ cmake -G "Unix Makefiles" -D CMAKE_C_COMPILER=$GCC_COMMAND -D CMAKE_CXX_COMPILER
 make -j
 make python -j
 cd ../
-

--- a/script/build_gcc_with_MPI.sh
+++ b/script/build_gcc_with_MPI.sh
@@ -1,30 +1,7 @@
 #!/bin/sh
 
-GCC_COMMAND="$C_COMPILER"
-GXX_COMMAND="$CXX_COMPILER"
-
-if [ -z "$GCC_COMMAND" ]; then
-  GCC_COMMAND="gcc"
-fi
-
-if [ -z "$GXX_COMMAND" ]; then
-  GXX_COMMAND="g++"
-fi
-
-# if gcc/g++ version is less than 8, use gcc-8/g++-8
-GCC_VERSION=$($GCC_COMMAND -dumpfullversion -dumpversion | awk -F. '{printf "%2d%02d%02d", $1,$2,$3}')
-if [ "$GCC_VERSION" -lt 80000 ]; then
-  GCC_COMMAND=gcc-7
-elif [ "$GCC_VERSION" -lt 90000 ]; then
-  GCC_COMMAND=gcc-8
-fi
-
-GXX_VERSION=$($GXX_COMMAND -dumpfullversion -dumpversion | awk -F. '{printf "%2d%02d%02d", $1,$2,$3}')
-if [ "$GXX_VERSION" -lt 80000 ]; then
-  GXX_COMMAND=g++-7
-elif [ "$GXX_VERSION" -lt 90000 ]; then
-  GXX_COMMAND=g++-8
-fi
+GCC_COMMAND=${C_COMPILER:-"gcc"}
+GXX_COMMAND=${CXX_COMPILER:-"g++"}
 
 mkdir ./build
 cd ./build
@@ -32,4 +9,3 @@ cmake -G "Unix Makefiles" -D CMAKE_C_COMPILER=$GCC_COMMAND -D CMAKE_CXX_COMPILER
 make -j
 make python -j
 cd ../
-

--- a/script/build_gcc_with_gpu.sh
+++ b/script/build_gcc_with_gpu.sh
@@ -1,17 +1,7 @@
 #!/bin/sh
 
-GCC_COMMAND=gcc
-GXX_COMMAND=g++
-
-# if gcc/g++ version is less than 7, use gcc-7/g++-7
-GCC_VERSION=$(gcc -dumpfullversion -dumpversion | awk -F. '{printf "%2d%02d%02d", $1,$2,$3}')
-if [ "$GCC_VERSION" -lt 70000 ]; then
-  GCC_COMMAND=gcc-7
-fi
-GXX_VERSION=$(g++ -dumpfullversion -dumpversion | awk -F. '{printf "%2d%02d%02d", $1,$2,$3}')
-if [ "$GXX_VERSION" -lt 70000 ]; then
-  GXX_COMMAND=g++-7
-fi
+GCC_COMMAND=${C_COMPILER:-"gcc"}
+GXX_COMMAND=${CXX_COMPILER:-"g++"}
 
 mkdir ./build
 cd ./build
@@ -19,4 +9,3 @@ cmake -G "Unix Makefiles" -D CMAKE_C_COMPILER=$GCC_COMMAND -D CMAKE_CXX_COMPILER
 make -j
 make python -j
 cd ../
-


### PR DESCRIPTION
バージョンに合わせて gcc のバイナリを上書きする部分がありましたが，挙動が分かりにくかったりするので削除します．
`gcc` でないコンパイラを使うときは
```
C_COMPILER=gcc-8 CXX_COMPILER=g++-8 ./script/build_gcc.sh
```
のように環境変数で指定してください．