### PR TITLE
Bugfix/mac ci boost failing

### DIFF
--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -43,7 +43,8 @@ jobs:
       
       - name: Install Boost for macOS
         run: |
-          brew install boost -f
+          brew upgrade
+          brew install boost
           brew link boost
         if: ${{ contains(matrix.os, 'macos') }}
 


### PR DESCRIPTION
brew upgradeをbrew install boostの前に挟むことでboostのバージョンupgradeが必要な場合のエラーが出ないようにしました。