### PR TITLE
[Bug] Fixing GradCalculatorMPI's argument

### DIFF
--- a/src/mpisim/GradCalculatorMPI.cpp
+++ b/src/mpisim/GradCalculatorMPI.cpp
@@ -5,7 +5,7 @@
 #include "utils.hpp"
 
 std::vector<std::complex<double>> GradCalculatorMPI::calculate_grad(
-    ParametricQuantumCircuit& x, Observable& obs, double theta) {
+    ParametricQuantumCircuit& x, Observable& obs, std::vector<double> theta) {
     std::vector<std::complex<double>> node_ans;
     int myrank, numprocs;
     MPI_Comm_rank(MPI_COMM_WORLD, &myrank);
@@ -19,7 +19,7 @@ std::vector<std::complex<double>> GradCalculatorMPI::calculate_grad(
                 if (i == q) {
                     diff = M_PI / 2.0;
                 }
-                x.set_parameter(q, theta + diff);
+                x.set_parameter(q, theta[q] + diff);
             }
             state.set_zero_state();
             x.update_quantum_state(&state);
@@ -32,7 +32,7 @@ std::vector<std::complex<double>> GradCalculatorMPI::calculate_grad(
                 if (i == q) {
                     diff = M_PI / 2.0;
                 }
-                x.set_parameter(q, theta - diff);
+                x.set_parameter(q, theta[q] - diff);
             }
             state.set_zero_state();
             x.update_quantum_state(&state);

--- a/src/mpisim/GradCalculatorMPI.hpp
+++ b/src/mpisim/GradCalculatorMPI.hpp
@@ -5,5 +5,5 @@
 class DllExport GradCalculatorMPI {
 public:
     std::vector<std::complex<double>> calculate_grad(
-        ParametricQuantumCircuit& x, Observable& obs, double theta);
+        ParametricQuantumCircuit& x, Observable& obs, std::vector<double> theta);
 };


### PR DESCRIPTION
GradCalculatorMPIの引数が間違っていて、GradCalculatorと互換性がなくなっていました。
このPRではこの問題を修正します。