### PR TITLE
Fixed the display of +-0 when -0.

### DIFF
--- a/src/cppsim_experimental/observable.cpp
+++ b/src/cppsim_experimental/observable.cpp
@@ -209,8 +209,9 @@ std::string Observable::to_string() {
     for (i = 0; i < get_term_count(); i++) {
         // (1.0-2.0j)
         ss << "(" << _coef_list[i].real();
-        if (0 <= _coef_list[i].imag()) ss << "+";
-        ss << _coef_list[i].imag() << "j) ";
+        // 虚数部には符号をつける
+        // +0j or -0j に対応させるためstd::showposを用いる
+        ss << std::showpos << _coef_list[i].imag() << "j) ";
 
         // [X 0 Y 1 Z 2]
         ss << "[" << _pauli_terms[i].to_string() << "]";
@@ -220,6 +221,8 @@ std::string Observable::to_string() {
         res += ss.str();
         ss.str("");
         ss.clear();
+        // noshowposして、1項目以降の実数部に符号が付かないようにする
+        ss << std::noshowpos;
     }
     return res;
 }

--- a/test/cppsim_experimental/test_observable.cpp
+++ b/test/cppsim_experimental/test_observable.cpp
@@ -105,6 +105,16 @@ TEST(ObservableTest, to_stringTest) {
     EXPECT_EQ(expected, observable.to_string());
 }
 
+TEST(ObservableTest, to_string_SignOfCoefTest) {
+    std::string expected =
+        "(0-0j) [I 0 ] +\n"
+        "(0+0j) [I 0 ]";
+    Observable observable;
+    observable.add_term(0.0 - 0.0i, "I 0");
+    observable.add_term(0.0 + 0.0i, "I 0");
+    EXPECT_EQ(expected, observable.to_string());
+}
+
 /*
 TEST(ObservableTest, CheckParsedObservableFromOpenFermionFile) {
     auto func = [](const std::string path,


### PR DESCRIPTION
数値として+0と-0を区別して保持するようで、-0jの時に+-0jと表示されてしまっていた。

そこで、係数が(0-0j)と(0+0j)となる時のテストケースを用意し、正しく表示されるように修正した。