### PR TITLE
Change return type of noise simulator

### DIFF
--- a/src/cppsim/noisesimulator.cpp
+++ b/src/cppsim/noisesimulator.cpp
@@ -52,12 +52,12 @@ NoiseSimulator::~NoiseSimulator() {
     delete circuit;
 }
 
-std::vector<UINT> NoiseSimulator::execute(const UINT sample_count) {
+std::vector<ITYPE> NoiseSimulator::execute(const UINT sample_count) {
     Random random;
     std::vector<std::vector<UINT>> trial_gates(
         sample_count, std::vector<UINT>(circuit->gate_list.size(), 0));
     for (UINT i = 0; i < sample_count; ++i) {
-        UINT gate_size = circuit->gate_list.size();
+        UINT gate_size = (UINT)circuit->gate_list.size();
         for (UINT q = 0; q < gate_size; ++q) {
             auto gate = circuit->gate_list[q];
             if (gate->is_noise() == false) continue;
@@ -65,7 +65,7 @@ std::vector<UINT> NoiseSimulator::execute(const UINT sample_count) {
             std::vector<double> itr = gate->get_cumulative_distribution();
             auto hoge = std::lower_bound(itr.begin(), itr.end(), val);
             assert(hoge != itr.begin());
-            trial_gates[i][q] = std::distance(itr.begin(), hoge) - 1;
+            trial_gates[i][q] = (UINT)(std::distance(itr.begin(), hoge) - 1);
         }
     }
 
@@ -95,7 +95,7 @@ std::vector<UINT> NoiseSimulator::execute(const UINT sample_count) {
     std::complex<long double> Fid = 0;
     */
     Common_state.load(initial_state);
-    std::vector<UINT> result(sample_count);
+    std::vector<ITYPE> result(sample_count);
     auto result_itr = result.begin();
     UINT done_itr = 0;  // for gates i such that i < done_itr, gate i is already
                         // applied to Common_state.
@@ -128,7 +128,7 @@ std::vector<UINT> NoiseSimulator::execute(const UINT sample_count) {
         }
     }
     // std::cout << Fid << std::endl;
-    std::mt19937 Randomizer(random.int64());
+    std::mt19937 Randomizer(random.int32());
     std::shuffle(begin(result), end(result), Randomizer);
 
     return result;
@@ -136,7 +136,7 @@ std::vector<UINT> NoiseSimulator::execute(const UINT sample_count) {
 
 void NoiseSimulator::evaluate_gates(const std::vector<UINT>& chosen_gate,
     QuantumState* sampling_state, const int StartPos) {
-    UINT gate_size = circuit->gate_list.size();
+    UINT gate_size = (UINT)circuit->gate_list.size();
     for (UINT q = StartPos; q < gate_size; ++q) {
         auto gate = circuit->gate_list[q];
         if (gate->is_noise() == false) {

--- a/src/cppsim/noisesimulator.hpp
+++ b/src/cppsim/noisesimulator.hpp
@@ -47,5 +47,5 @@ public:
      * @param[in] prob ノイズが乗る確率
      * @param[in] sample_count 行うsamplingの回数
      */
-    virtual std::vector<UINT> execute(const UINT sample_count);
+    virtual std::vector<ITYPE> execute(const UINT sample_count);
 };

--- a/test/cppsim/test_noisesimulator.cpp
+++ b/test/cppsim/test_noisesimulator.cpp
@@ -10,7 +10,7 @@
 
 TEST(NoiseSimulatorTest, Random_with_State_Test) {
     // Just Check whether they run without Runtime Errors.
-    int n = 10, depth = 10;
+    UINT n = 10, depth = 10;
     QuantumState state(n);
     state.set_Haar_random_state();
     QuantumCircuit circuit(n);
@@ -32,13 +32,13 @@ TEST(NoiseSimulatorTest, Random_with_State_Test) {
         }
     }
     NoiseSimulator hoge(&circuit, &state);
-    std::vector<unsigned int> result = hoge.execute(100);
+    std::vector<ITYPE> result = hoge.execute(100);
     return;
 }
 
 TEST(NoiseSimulatorTest, Random_without_State_Test) {
     // Just Check whether they run without Runtime Errors.
-    int n = 10, depth = 10;
+    UINT n = 10, depth = 10;
     QuantumCircuit circuit(n);
     Random random;
     for (UINT d = 0; d < depth; ++d) {
@@ -58,19 +58,19 @@ TEST(NoiseSimulatorTest, Random_without_State_Test) {
         }
     }
     NoiseSimulator hoge(&circuit);
-    std::vector<unsigned int> result = hoge.execute(100);
+    std::vector<ITYPE> result = hoge.execute(100);
     return;
 }
 
 TEST(NoiseSimulatorTest, H_gate_twice_test) {
-    int n = 4;
+    UINT n = 4;
     QuantumCircuit circuit(n);
     circuit.add_noise_gate(gate::H(0), "Depolarizing", 0.02);
     circuit.add_noise_gate(gate::H(0), "Depolarizing", 0.02);
     NoiseSimulator hoge(&circuit);
-    std::vector<unsigned int> result = hoge.execute(10000);
+    std::vector<ITYPE> result = hoge.execute(10000);
     int cnts[2] = {};
-    for (int i = 0; i < result.size(); ++i) {
+    for (UINT i = 0; i < result.size(); ++i) {
         cnts[result[i]]++;
     }
     ASSERT_NE(cnts[0], 0);


### PR DESCRIPTION
I've updated the return type of noise sampling from `UINT` (32bit) to `ITYPE` (64bit) for consistency to the return type of `state::sampling`.
Also, I've fixed several warnings in type mismatch at MSVC.
