### PR TITLE
term_dictに関するバグ修正

### DIFF
--- a/src/cppsim_experimental/observable.cpp
+++ b/src/cppsim_experimental/observable.cpp
@@ -74,8 +74,14 @@ void Observable::add_term(const CPPCTYPE coef, std::string s) {
 }
 
 void Observable::remove_term(UINT index) {
+    this->_term_dict.erase(this->_pauli_terms.at(index).to_string());
     this->_coef_list.erase(this->_coef_list.begin() + index);
     this->_pauli_terms.erase(this->_pauli_terms.begin() + index);
+
+    // index番目の項を削除したので、index番目以降の項のindexが1つずれる
+    for(ITYPE i = 0; i < this->_coef_list.size() - index; i++) {
+        this->_term_dict[this->_pauli_terms.at(index + i).to_string()] = index + i;
+    }
 }
 
 CPPCTYPE Observable::get_expectation_value(

--- a/test/cppsim_experimental/test_observable.cpp
+++ b/test/cppsim_experimental/test_observable.cpp
@@ -153,6 +153,28 @@ TEST(ObservableTest, calc_coefTest){
     EXPECT_EQ(PAULI_ID_X, ZY.get_term(0).second.get_pauli_id_list().at(0));
 }
 
+TEST(ObservableTest, remove_term_Test){
+    Observable ob;
+    ob.add_term(1.0, "X 0");
+    ob.add_term(1.0, "Y 1");
+    ob.add_term(1.0, "Z 2");
+    ob.add_term(1.0, "X 3");
+
+    auto dict1 = ob.get_dict();
+    EXPECT_EQ(4, dict1.size());
+    EXPECT_EQ(0, dict1["X 0 "]);
+    EXPECT_EQ(1, dict1["Y 1 "]);
+    EXPECT_EQ(2, dict1["Z 2 "]);
+    EXPECT_EQ(3, dict1["X 3 "]);
+
+    ob.remove_term(1);
+    auto dict2 = ob.get_dict();
+    EXPECT_EQ(3, dict2.size());
+    EXPECT_EQ(0, dict2["X 0 "]);
+    EXPECT_EQ(1, dict2["Z 2 "]);
+    EXPECT_EQ(2, dict2["X 3 "]);
+}
+
 TEST(ObservableTest, term_dict_SizeTest){
     Observable x_term, y_term, xy_term;
     Observable ob;


### PR DESCRIPTION
term_dictに関する以下のバグを修正しました。

- `operator*=()`で、`_term_dict`も`clear()`を実行するように修正
- `remove_term()`で項を削除する際に、`_term_dict`からも項の情報を削除するように修正
- `remove_term()`で項を削除したことにより、`_term_dict`が持つindex情報が1つずれるため、それらを更新する処理を追加