### PR TITLE
skip cp310-manylinux_x86_64 build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,6 +185,8 @@ jobs:
       # cf. https://stackoverflow.com/a/55500164
       CIBW_BEFORE_BUILD_MACOS: "brew link --overwrite gcc@8 && pip install cmake"
       CIBW_BUILD: "cp3*-macosx_x86_64 cp3*-manylinux_x86_64 cp3*-win_amd64"
+      # See https://github.com/Qulacs-Osaka/qulacs-osaka/issues/106
+      CIBW_SKIP: "cp310-manylinux_x86_64"
       CIBW_BUILD_VERBOSITY: "1"
       CIBW_ENVIRONMENT: 'QULACS_OPT_FLAGS="-mtune=haswell -mfpmath=both"'
       CIBW_REPAIR_WHEEL_COMMAND_MACOS: "delocate-listdeps {wheel} && script/fix_wheel_osx.sh {wheel} {dest_dir} && delocate-listdeps {wheel}"


### PR DESCRIPTION
scipyのwheelが配布されるまで、CPython 3.10向けのwheelbuildをスキップすることで、CIがfailしないようにします

