### PR TITLE
Run test serially in Ubuntu CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,8 +53,8 @@ jobs:
       - name: Test in Ubuntu
         run: |
           cd ./build
-          make test -j
-          make pythontest -j
+          make test
+          make pythontest
         if: ${{ contains(matrix.os, 'ubuntu') }}
 
   nvcc-gcc8-GPUbuild:


### PR DESCRIPTION
close #127 
CI でテストを実行する際に `make test -j` としていましたが，`-j` を取り除いて直列に実行するようにすると数分で実行が完了しました．
例: https://github.com/Qulacs-Osaka/qulacs-osaka/runs/3595561917?check_suite_focus=true
public 化して GitHub 側で CI を動かせるようになるまではこれで問題ないと思います．