### PR TITLE
Ccache in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,7 @@ jobs:
 
       - name: Install qulacs for Ubuntu
         run: ./script/build_gcc.sh
+        if: ${{ contains(matrix.os, 'ubuntu') }}
 
       - name: Install qulacs Python module
         run: python setup.py install
@@ -53,9 +54,10 @@ jobs:
           cd ./build
           make test
           make pythontest
+        if: ${{ contains(matrix.os, 'ubuntu') }}
 
       - name: Show cache stats
-        run: ccache -s -v
+        run: ccache -s
 
   nvcc-gcc8-GPUbuild:
     name: nvcc + gcc8 build
@@ -85,6 +87,7 @@ jobs:
 
       - name: Install qulacs for Ubuntu
         run: ./script/build_gcc_with_gpu.sh
+        if: ${{ contains(matrix.os, 'ubuntu') }}
 
       - name: Install qulacs Python module
         run: python setup.py install
@@ -94,6 +97,7 @@ jobs:
           cd ./build
           make test -j
           make pythontest -j
+        if: ${{ contains(matrix.os, 'ubuntu') }}
 
   source-dist:
     name: Source dist


### PR DESCRIPTION
close #125 
CI でのビルドに ccache を使ってビルド成果物をキャッシュすることで実行時間がより短くなりました．
例: https://github.com/Qulacs-Osaka/qulacs-osaka/runs/3660501782?check_suite_focus=true

ccache で生成したビルドキャッシュを actions/cache で取り出しているのですが，[GitHub のドキュメント](https://docs.github.com/en/actions/guides/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache) によると
> A workflow can access and restore a cache created in the current branch, the base branch (including base branches of forked repositories), or the default branch (usually `main`).

ということなので，大抵のブランチでキャッシュを利用できるはずです．