### PR TITLE
Remove matrix.os of GCC8 build in Ubuntu CI

### DIFF
--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -84,7 +84,6 @@ jobs:
 
       - name: Install qulacs for Ubuntu
         run: ./script/build_gcc_with_gpu.sh
-        if: ${{ contains(matrix.os, 'ubuntu') }}
 
       - name: Install qulacs Python module
         run: python setup.py install
@@ -94,7 +93,6 @@ jobs:
           cd ./build
           make test -j
           make pythontest -j
-        if: ${{ contains(matrix.os, 'ubuntu') }}
 
   source-dist:
     name: Source dist


### PR DESCRIPTION
`docker-runner` を指定していたことで `if: ${{ contains(matrix.os, 'ubuntu') }}` が `true` にならずにテストが走っていなかった問題を修正しました．