### PR TITLE
[feat] Add Python 3.10_manylinux to wheel build

### DIFF
--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -29,7 +29,7 @@ jobs:
       # The following command fixes this issue by (brew) re-linking files from gcc-8.
       # cf. https://stackoverflow.com/a/55500164
       CIBW_BEFORE_BUILD_MACOS: "brew install gcc@8 && brew link --overwrite gcc@8 && pip install cmake && brew upgrade && brew install -f boost && brew link boost"
-      CIBW_BUILD: "cp3*-macosx_x86_64 cp3*-manylinux_x86_64 cp3*-win_amd64"
+      CIBW_BUILD: "cp310*-macosx_x86_64 cp310*-manylinux_x86_64 cp310*-win_amd64"
 
       # necessary for compiling python pillow library required to install numpy,scipy,openfermion.
       CIBW_BEFORE_TEST_LINUX: "yum install libjpeg-devel -y"

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -32,7 +32,6 @@ jobs:
       CIBW_BEFORE_BUILD_MACOS: "brew link --overwrite gcc@8 && pip install cmake && brew upgrade && brew install -f boost && brew link boost"
       CIBW_BUILD: "cp3*-macosx_x86_64 cp3*-manylinux_x86_64 cp3*-win_amd64"
       # See https://github.com/Qulacs-Osaka/qulacs-osaka/issues/106
-      CIBW_SKIP: "cp310-manylinux_x86_64"
       CIBW_BUILD_VERBOSITY: "1"
       CIBW_ENVIRONMENT: 'QULACS_OPT_FLAGS="-mtune=haswell -mfpmath=both"'
       CIBW_REPAIR_WHEEL_COMMAND_MACOS: "delocate-listdeps {wheel} && script/fix_wheel_osx.sh {wheel} {dest_dir} && delocate-listdeps {wheel}"

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -29,7 +29,7 @@ jobs:
       # The following command fixes this issue by (brew) re-linking files from gcc-8.
       # cf. https://stackoverflow.com/a/55500164
       CIBW_BEFORE_BUILD_MACOS: "brew install gcc@8 && brew link --overwrite gcc@8 && pip install cmake && brew upgrade && brew install -f boost && brew link boost"
-      CIBW_BUILD: "cp310*-macosx_x86_64 cp310*-manylinux_x86_64 cp310*-win_amd64"
+      CIBW_BUILD: "cp3*-macosx_x86_64 cp3*-manylinux_x86_64 cp3*-win_amd64"
 
       # necessary for compiling python pillow library required to install numpy,scipy,openfermion.
       CIBW_BEFORE_TEST_LINUX: "yum install libjpeg-devel -y"


### PR DESCRIPTION
close #109 
# 概要
Python 3.10用wheelがビルドできるようになったので、修正を加えました。