### PR TITLE
[Fix] :bug: use QULACS_OPT_FLAGS in CI

### DIFF
--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -14,7 +14,7 @@ jobs:
     env:
       CXX_COMPILER: "/usr/lib/ccache/g++"
       C_COMPILER: "/usr/lib/ccache/gcc"
-      OPT_FLAGS: "-mtune=haswell -march=haswell -mfpmath=both"
+      QULACS_OPT_FLAGS: "-mtune=haswell -march=haswell -mfpmath=both"
       PYTHON: ${{ matrix.python-version }}
       COVERAGE: "ON"
       CACHE_NAME: ccache-qulacs-build-v2
@@ -66,6 +66,7 @@ jobs:
     env:
       CXX_COMPILER: "/usr/lib/ccache/g++"
       C_COMPILER: "/usr/lib/ccache/gcc"
+      QULACS_OPT_FLAGS: "-mtune=haswell -march=haswell -mfpmath=both"
       PYTHON: "3.7.5"
       COVERAGE: "ON"
       CACHE_NAME: ccache-qulacs-gpu-build-v2

--- a/script/build_gcc.sh
+++ b/script/build_gcc.sh
@@ -2,7 +2,7 @@
 
 GCC_COMMAND=${C_COMPILER:-"gcc"}
 GXX_COMMAND=${CXX_COMPILER:-"g++"}
-OPT_FLAGS=${OPT_FLAGS:-"-mtune=native -march=native -mfpmath=both"}
+OPT_FLAGS=${QULACS_OPT_FLAGS:-"-mtune=native -march=native -mfpmath=both"}
 
 mkdir ./build
 cd ./build

--- a/script/build_gcc_with_gpu.sh
+++ b/script/build_gcc_with_gpu.sh
@@ -2,10 +2,11 @@
 
 GCC_COMMAND=${C_COMPILER:-"gcc"}
 GXX_COMMAND=${CXX_COMPILER:-"g++"}
+OPT_FLAGS=${QULACS_OPT_FLAGS:-"-mtune=native -march=native -mfpmath=both"}
 
 mkdir ./build
 cd ./build
-cmake -G "Unix Makefiles" -D CMAKE_C_COMPILER=$GCC_COMMAND -D CMAKE_CXX_COMPILER=$GXX_COMMAND -D CMAKE_BUILD_TYPE=Release -D USE_GPU:STR=Yes ..
+cmake -G "Unix Makefiles" -D CMAKE_C_COMPILER=$GCC_COMMAND -D CMAKE_CXX_COMPILER=$GXX_COMMAND -D OPT_FLAGS="$OPT_FLAGS" -D CMAKE_BUILD_TYPE=Release -D USE_GPU:STR=Yes ..
 make -j
 make python -j
 cd ../


### PR DESCRIPTION
# 概要
pythontestではアーキテクチャの設定を変更していないため、Illegal Instructionで落ちてしまっていました。
setup.pyは`QULACS_OPT_FLAGS`の設定を読みに行っているため、環境変数名を`OPT_FLAGS` -> `QULACS_OPT_FLAGS`に変更しました。