### PR TITLE
[Feat] :hammer: add make -j $(nproc) option

### DIFF
--- a/script/build_gcc.sh
+++ b/script/build_gcc.sh
@@ -7,6 +7,6 @@ OPT_FLAGS=${QULACS_OPT_FLAGS:-"-mtune=native -march=native -mfpmath=both"}
 mkdir ./build
 cd ./build
 cmake -G "Unix Makefiles" -D CMAKE_C_COMPILER=$GCC_COMMAND -D CMAKE_CXX_COMPILER=$GXX_COMMAND -D OPT_FLAGS="$OPT_FLAGS" -D CMAKE_BUILD_TYPE=Release-D USE_GPU:STR=No ..
-make -j
-make python -j
+make -j $(nproc)
+make python -j $(nproc)
 cd ../

--- a/script/build_gcc_with_gpu.sh
+++ b/script/build_gcc_with_gpu.sh
@@ -7,6 +7,6 @@ OPT_FLAGS=${QULACS_OPT_FLAGS:-"-mtune=native -march=native -mfpmath=both"}
 mkdir ./build
 cd ./build
 cmake -G "Unix Makefiles" -D CMAKE_C_COMPILER=$GCC_COMMAND -D CMAKE_CXX_COMPILER=$GXX_COMMAND -D OPT_FLAGS="$OPT_FLAGS" -D CMAKE_BUILD_TYPE=Release -D USE_GPU:STR=Yes ..
-make -j
-make python -j
+make -j $(nproc)
+make python -j $(nproc)
 cd ../


### PR DESCRIPTION
closing #176

makeの-jオプションに論理コア数を指定して、並列数を下げることでビルド中にOOMエラーが発生することを防ぐよう修正しました。