### PR TITLE
disable to activate venv

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -26,6 +26,7 @@
 			"source.organizeImports": true
 		},
 		"python.linting.mypyEnabled": true,
+		"python.terminal.activateEnvironment": false
 	},
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [


### PR DESCRIPTION
close #180 
`"python.terminal.activateEnvironment": false` を追加したところ勝手に`pyenv shell 3.9.5`が走らなくなりました。