### PR TITLE
Change build to using docker image In checking format

### DIFF
--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -190,7 +190,7 @@ jobs:
         if: ${{ github.event_name == 'push' }}
         run: |
           cd /
-          git clone -b ${{github.ref#refs/heads/}} https://github.com/Qulacs-Osaka/qulacs-osaka
+          git clone -b ${{github.ref}} https://github.com/Qulacs-Osaka/qulacs-osaka
 
       - name: format
         run: qulacs_format

--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -182,9 +182,14 @@ jobs:
     steps:
       - name: clone qulacs-osaka
         run: git clone https://github.com/Qulacs-Osaka/qulacs-osaka
+      
+      - name: test
+        run: ls -al /qulacs-osaka
 
       - name: format
-        run: qulacs_format
+        run: |
+          cd qulacs-osaka
+          qulacs_format
 
       - name: Compare diff
         run: |

--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -185,7 +185,7 @@ jobs:
       - name: clone qulacs-osaka
         run: |
           cd /
-          git clone -b "$BRANCH_NAME" https://github.com/Qulacs-Osaka/qulacs-osaka
+          git clone -b $BRANCH_NAME https://github.com/Qulacs-Osaka/qulacs-osaka
 
       - name: format
         run: qulacs_format

--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -176,6 +176,7 @@ jobs:
 
   format:
     name: Format with clang-format
+    runs-on: "ubuntu-20.04"
     container:
       image: ghcr.io/qulacs-osaka/qulacs-ubuntu-clang-format:latest
     steps:

--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -187,7 +187,7 @@ jobs:
 
       - name: format
         run: |
-          cd qulacs-osaka
+          cd /qulacs-osaka
           qulacs_format
 
       - name: Compare diff

--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -180,8 +180,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Use Docker image
-        uses: docker://ghcr.io/qulacs-osaka/qulacs-ubuntu-clang-format:latest
+      - name: clang-format
+        run: docker run --rm -it -v `pwd`:/qulacs-osaka -e LOCAL_UID=`id -u $USER` -e LOCAL_GID=`id -g $USER` ghcr.io/qulacs-osaka/qulacs-ubuntu-clang-format:latest
 
       - name: Compare diff
         run: |

--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -180,14 +180,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Setup cmake
-        uses: lukka/get-cmake@latest
-
-      - name: Install boost
-        run: sudo apt install libboost-dev
-
-      - name: Run clang-format
-        run: cmake --build build --target format
+      - name: Use Docker image
+        uses: docker://ghcr.io/qulacs-osaka/qulacs-ubuntu-clang-format:latest
 
       - name: Compare diff
         run: |

--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -179,7 +179,8 @@ jobs:
     runs-on: "ubuntu-20.04"
     container:
       image: ghcr.io/qulacs-osaka/qulacs-ubuntu-clang-format:latest
-      env : BRANCH_NAME: ${{github.head_ref}}
+      env:
+        BRANCH_NAME: ${{github.head_ref}}
     steps:
       - name: clone qulacs-osaka
         run: |

--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -181,10 +181,9 @@ jobs:
       image: ghcr.io/qulacs-osaka/qulacs-ubuntu-clang-format:latest
     steps:
       - name: clone qulacs-osaka
-        run: git clone https://github.com/Qulacs-Osaka/qulacs-osaka
-      
-      - name: test
-        run: ls -al qulacs-osaka/
+        run: |
+          cd /
+          git clone https://github.com/Qulacs-Osaka/qulacs-osaka
 
       - name: format
         run: |

--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -180,11 +180,9 @@ jobs:
     container:
       image: ghcr.io/qulacs-osaka/qulacs-ubuntu-clang-format:latest
     steps:
-      - name: Get Branch Name
+      - name: clone qulacs-osaka
         env:
           BRANCH_NAME: ${{github.head_ref}}
-
-      - name: clone qulacs-osaka
         run: |
           cd /
           git clone -b $BRANCH_NAME https://github.com/Qulacs-Osaka/qulacs-osaka

--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -184,7 +184,7 @@ jobs:
         run: git clone https://github.com/Qulacs-Osaka/qulacs-osaka
 
       - name: format
-        run: bash qulacs_format.sh
+        run: bash qulacs-osaka/qulacs_format.sh
 
       - name: Compare diff
         run: |

--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -192,6 +192,7 @@ jobs:
 
       - name: Compare diff
         run: |
+          cd /qulacs-osaka
           diff=$(git diff)
           echo -n "$diff"
           # Without `-n`, `echo -n "$diff" | wc -l` is 1 even if `"$diff" is empty.`

--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -184,7 +184,7 @@ jobs:
         run: git clone https://github.com/Qulacs-Osaka/qulacs-osaka
       
       - name: test
-        run: ls -al /qulacs-osaka
+        run: ls -al qulacs-osaka/
 
       - name: format
         run: |

--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -176,15 +176,14 @@ jobs:
 
   format:
     name: Format with clang-format
-    runs-on: "ubuntu-20.04"
     container:
       image: ghcr.io/qulacs-osaka/qulacs-ubuntu-clang-format:latest
     steps:
       - name: clone qulacs-osaka
         run: git clone https://github.com/Qulacs-Osaka/qulacs-osaka
 
-      - name: clang-format
-        uses: bash qulacs_format.sh
+      - name: format
+        run: bash qulacs_format.sh
 
       - name: Compare diff
         run: |

--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -178,14 +178,12 @@ jobs:
     name: Format with clang-format
     runs-on: "ubuntu-20.04"
     container:
-      env:
-        BRANCH_NAME: ${{github.head_ref}}
       image: ghcr.io/qulacs-osaka/qulacs-ubuntu-clang-format:latest
     steps:
       - name: clone /qulacs-osaka
         run: |
           cd /
-          git clone -b $BRANCH_NAME https://github.com/Qulacs-Osaka/qulacs-osaka
+          git clone -b ${{ github.head_ref }} https://github.com/Qulacs-Osaka/qulacs-osaka
 
       - name: format
         run: qulacs_format

--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -184,9 +184,7 @@ jobs:
         run: git clone https://github.com/Qulacs-Osaka/qulacs-osaka
 
       - name: format
-        run: |
-          cd qulacs-osaka
-          qulacs_format
+        run: qulacs_format
 
       - name: Compare diff
         run: |

--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -190,7 +190,7 @@ jobs:
         if: ${{ github.event_name == 'push' }}
         run: |
           cd /
-          git clone -b ${{github.base_ref}} https://github.com/Qulacs-Osaka/qulacs-osaka
+          git clone -b ${{github.ref#refs/heads/}} https://github.com/Qulacs-Osaka/qulacs-osaka
 
       - name: format
         run: qulacs_format

--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -179,9 +179,11 @@ jobs:
     runs-on: "ubuntu-20.04"
     container:
       image: ghcr.io/qulacs-osaka/qulacs-ubuntu-clang-format:latest
-      env:
-        BRANCH_NAME: ${{github.head_ref}}
     steps:
+      - name: Get Branch Name
+        env:
+          BRANCH_NAME: ${{github.head_ref}}
+
       - name: clone qulacs-osaka
         run: |
           cd /

--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -184,7 +184,9 @@ jobs:
         run: git clone https://github.com/Qulacs-Osaka/qulacs-osaka
 
       - name: format
-        run: bash qulacs-osaka/qulacs_format.sh
+        run: |
+          cd qulacs-osaka
+          qulacs_format
 
       - name: Compare diff
         run: |

--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -186,9 +186,7 @@ jobs:
           git clone https://github.com/Qulacs-Osaka/qulacs-osaka
 
       - name: format
-        run: |
-          cd /qulacs-osaka
-          qulacs_format
+        run: qulacs_format
 
       - name: Compare diff
         run: |

--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -184,13 +184,13 @@ jobs:
         if: ${{ github.event_name == 'pull_request' }}
         run: |
           cd /
-          git clone -b ${{github.head_ref}} https://github.com/Qulacs-Osaka/qulacs-osaka
+          git clone -b "${GITHUB_HEAD_REF#refs/heads/}" https://github.com/Qulacs-Osaka/qulacs-osaka
         
       - name: clone /qulacs-osaka (push)
         if: ${{ github.event_name == 'push' }}
         run: |
           cd /
-          git clone -b ${{github.ref}} https://github.com/Qulacs-Osaka/qulacs-osaka
+          git clone -b "${GITHUB_REF#refs/heads/}" https://github.com/Qulacs-Osaka/qulacs-osaka
 
       - name: format
         run: qulacs_format

--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -180,10 +180,17 @@ jobs:
     container:
       image: ghcr.io/qulacs-osaka/qulacs-ubuntu-clang-format:latest
     steps:
-      - name: clone /qulacs-osaka
+      - name: clone /qulacs-osaka (pull_request)
+        if: ${{ github.event_name == 'pull_request' }}
         run: |
           cd /
-          git clone -b ${{ github.head_ref }} https://github.com/Qulacs-Osaka/qulacs-osaka
+          git clone -b ${{github.head_ref}} https://github.com/Qulacs-Osaka/qulacs-osaka
+        
+      - name: clone /qulacs-osaka (push)
+        if: ${{ github.event_name == 'push' }}
+        run: |
+          cd /
+          git clone -b ${{github.base_ref}} https://github.com/Qulacs-Osaka/qulacs-osaka
 
       - name: format
         run: qulacs_format

--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -186,9 +186,6 @@ jobs:
       - name: Install boost
         run: sudo apt install libboost-dev
 
-      - name: Install qulacs for Ubuntu
-        run: ./script/build_gcc.sh
-
       - name: Run clang-format
         run: cmake --build build --target format
 

--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -179,11 +179,12 @@ jobs:
     runs-on: "ubuntu-20.04"
     container:
       image: ghcr.io/qulacs-osaka/qulacs-ubuntu-clang-format:latest
+      env : BRANCH_NAME: ${{github.head_ref}}
     steps:
       - name: clone qulacs-osaka
         run: |
           cd /
-          git clone https://github.com/Qulacs-Osaka/qulacs-osaka
+          git clone -b "$BRANCH_NAME" https://github.com/Qulacs-Osaka/qulacs-osaka
 
       - name: format
         run: qulacs_format

--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -178,11 +178,11 @@ jobs:
     name: Format with clang-format
     runs-on: "ubuntu-20.04"
     container:
+      env:
+        BRANCH_NAME: ${{github.head_ref}}
       image: ghcr.io/qulacs-osaka/qulacs-ubuntu-clang-format:latest
     steps:
-      - name: clone qulacs-osaka
-        env:
-          BRANCH_NAME: ${{github.head_ref}}
+      - name: clone /qulacs-osaka
         run: |
           cd /
           git clone -b $BRANCH_NAME https://github.com/Qulacs-Osaka/qulacs-osaka

--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -177,11 +177,14 @@ jobs:
   format:
     name: Format with clang-format
     runs-on: "ubuntu-20.04"
+    container:
+      image: ghcr.io/qulacs-osaka/qulacs-ubuntu-clang-format:latest
     steps:
-      - uses: actions/checkout@v2
+      - name: clone qulacs-osaka
+        run: git clone https://github.com/Qulacs-Osaka/qulacs-osaka
 
       - name: clang-format
-        run: docker run --rm -it -v `pwd`:/qulacs-osaka -e LOCAL_UID=`id -u $USER` -e LOCAL_GID=`id -g $USER` ghcr.io/qulacs-osaka/qulacs-ubuntu-clang-format:latest
+        uses: bash qulacs_format.sh
 
       - name: Compare diff
         run: |


### PR DESCRIPTION
close #171

`ci_ubuntu.yml`において、clang-formatをする際にbuildしていたものをclang-formatを行う[docker image](https://github.com/qulacs-osaka/qulacs-docker-images/pkgs/container/qulacs-ubuntu-clang-format)を使用する方法に変更しました。