### PR TITLE
add exception in cppsim

### DIFF
--- a/src/cppsim/circuit.cpp
+++ b/src/cppsim/circuit.cpp
@@ -21,11 +21,11 @@ bool check_gate_index(
 
 void QuantumCircuit::update_quantum_state(QuantumStateBase* state) {
     if (state->qubit_count != this->qubit_count) {
-        std::cerr << "Error: "
-                     "QuantumCircuit::update_quantum_state(QuantumStateBase) : "
-                     "invalid qubit count"
-                  << std::endl;
-        return;
+        std::stringstream ss;
+        ss << "Error: "
+              "QuantumCircuit::update_quantum_state(QuantumStateBase) : "
+              "invalid qubit count";
+        throw std::invalid_argument(ss.str());
     }
 
     for (const auto& gate : this->_gate_list) {
@@ -36,28 +36,25 @@ void QuantumCircuit::update_quantum_state(QuantumStateBase* state) {
 void QuantumCircuit::update_quantum_state(
     QuantumStateBase* state, UINT start, UINT end) {
     if (state->qubit_count != this->qubit_count) {
-        std::cerr
-            << "Error: "
-               "QuantumCircuit::update_quantum_state(QuantumStateBase,UINT,"
-               "UINT) : invalid qubit count"
-            << std::endl;
-        return;
+        std::stringstream ss;
+        ss << "Error: "
+              "QuantumCircuit::update_quantum_state(QuantumStateBase,UINT,"
+              "UINT) : invalid qubit count";
+        throw std::invalid_argument(ss.str());
     }
     if (start > end) {
-        std::cerr
-            << "Error: "
-               "QuantumCircuit::update_quantum_state(QuantumStateBase,UINT,"
-               "UINT) : start must be smaller than or equal to end"
-            << std::endl;
-        return;
+        std::stringstream ss;
+        ss << "Error: "
+              "QuantumCircuit::update_quantum_state(QuantumStateBase,UINT,"
+              "UINT) : start must be smaller than or equal to end";
+        throw std::invalid_argument(ss.str());
     }
     if (end > this->_gate_list.size()) {
-        std::cerr
-            << "Error: "
-               "QuantumCircuit::update_quantum_state(QuantumStateBase,UINT,"
-               "UINT) : end must be smaller than or equal to gate_count"
-            << std::endl;
-        return;
+        std::stringstream ss;
+        ss << "Error: "
+              "QuantumCircuit::update_quantum_state(QuantumStateBase,UINT,"
+              "UINT) : end must be smaller than or equal to gate_count";
+        throw std::invalid_argument(ss.str());
     }
     for (UINT cursor = start; cursor < end; ++cursor) {
         this->_gate_list[cursor]->update_quantum_state(state);
@@ -102,30 +99,29 @@ bool check_gate_index(
 
 void QuantumCircuit::add_gate(QuantumGateBase* gate) {
     if (!check_gate_index(this, gate)) {
-        std::cerr << "Error: QuatnumCircuit::add_gate(QuantumGateBase*): gate "
-                     "must be "
-                     "applied to qubits of which the indices are smaller than "
-                     "qubit_count"
-                  << std::endl;
-        return;
+        std::stringstream ss;
+        ss << "Error: QuatnumCircuit::add_gate(QuantumGateBase*): gate "
+              "must be "
+              "applied to qubits of which the indices are smaller than "
+              "qubit_count";
+        throw std::invalid_argument(ss.str());
     }
     this->_gate_list.push_back(gate);
 }
 
 void QuantumCircuit::add_gate(QuantumGateBase* gate, UINT index) {
     if (!check_gate_index(this, gate)) {
-        std::cerr << "Error: QuatnumCircuit::add_gate(QuantumGateBase*, UINT): "
-                     "gate must be applied to qubits of which the indices are "
-                     "smaller than qubit_count"
-                  << std::endl;
-        return;
+        std::stringstream ss;
+        ss << "Error: QuatnumCircuit::add_gate(QuantumGateBase*, UINT): "
+              "gate must be applied to qubits of which the indices are "
+              "smaller than qubit_count";
+        throw std::invalid_argument(ss.str());
     }
     if (index > this->_gate_list.size()) {
-        std::cerr
-            << "Error: QuantumCircuit::add_gate(QuantumGateBase*, UINT) : "
-               "insert index must be smaller than or equal to gate_count"
-            << std::endl;
-        return;
+        std::stringstream ss;
+        ss << "Error: QuantumCircuit::add_gate(QuantumGateBase*, UINT) : "
+              "insert index must be smaller than or equal to gate_count";
+        throw std::invalid_argument(ss.str());
     }
     this->_gate_list.insert(this->_gate_list.begin() + index, gate);
 }
@@ -154,62 +150,71 @@ void QuantumCircuit::add_noise_gate(
             this->add_gate(
                 gate::TwoQubitDepolarizingNoise(itr[0], itr[1], noise_prob));
         } else {
-            std::cerr << "Error: "
-                         "QuantumCircuit::add_noise_gate(QuantumGateBase*,"
-                         "string,double) : "
-                         "depolarizing noise can be used up to 2 qubits, but "
-                         "this gate has "
-                      << itr.size() << " qubits." << std::endl;
+            std::stringstream ss;
+            ss << "Error: "
+                  "QuantumCircuit::add_noise_gate(QuantumGateBase*,"
+                  "string,double) : "
+                  "depolarizing noise can be used up to 2 qubits, but "
+                  "this gate has "
+               << itr.size() << " qubits.";
+            throw std::invalid_argument(ss.str());
         }
     } else if (noise_type == "BitFlip") {
         if (itr.size() == 1) {
             this->add_gate(gate::BitFlipNoise(itr[0], noise_prob));
         } else {
-            std::cerr
-                << "Error: "
-                   "QuantumCircuit::add_noise_gate(QuantumGateBase*,string,"
-                   "double) : "
-                   "BitFlip noise can be used by 1 qubits, but this gate has "
-                << itr.size() << " qubits." << std::endl;
+            std::stringstream ss;
+            ss << "Error: "
+                  "QuantumCircuit::add_noise_gate(QuantumGateBase*,string,"
+                  "double) : "
+                  "BitFlip noise can be used by 1 qubits, but this gate has "
+               << itr.size() << " qubits.";
+            throw std::invalid_argument(ss.str());
         }
     } else if (noise_type == "Dephasing") {
         if (itr.size() == 1) {
             this->add_gate(gate::DephasingNoise(itr[0], noise_prob));
         } else {
-            std::cerr
-                << "Error: "
-                   "QuantumCircuit::add_noise_gate(QuantumGateBase*,string,"
-                   "double) : "
-                   "Dephasing noise can be used by 1 qubits, but this gate has "
-                << itr.size() << " qubits." << std::endl;
+            std::stringstream ss;
+            ss << "Error: "
+                  "QuantumCircuit::add_noise_gate(QuantumGateBase*,string,"
+                  "double) : "
+                  "Dephasing noise can be used by 1 qubits, but this gate has "
+               << itr.size() << " qubits.";
+            throw std::invalid_argument(ss.str());
         }
     } else if (noise_type == "IndependentXZ") {
         if (itr.size() == 1) {
             this->add_gate(gate::IndependentXZNoise(itr[0], noise_prob));
         } else {
-            std::cerr << "Error: "
-                         "QuantumCircuit::add_noise_gate(QuantumGateBase*,"
-                         "string,double) : "
-                         "IndependentXZ noise can be used by 1 qubits, but "
-                         "this gate has "
-                      << itr.size() << " qubits." << std::endl;
+            std::stringstream ss;
+            ss << "Error: "
+                  "QuantumCircuit::add_noise_gate(QuantumGateBase*,"
+                  "string,double) : "
+                  "IndependentXZ noise can be used by 1 qubits, but "
+                  "this gate has "
+               << itr.size() << " qubits.";
+            throw std::invalid_argument(ss.str());
         }
     } else if (noise_type == "AmplitudeDamping") {
         if (itr.size() == 1) {
             this->add_gate(gate::AmplitudeDampingNoise(itr[0], noise_prob));
         } else {
-            std::cerr
-                << "Error: "
-                   "QuantumCircuit::add_noise_gate(QuantumGateBase*,string,"
-                   "double) : AmplitudeDamping noise can be used by 1 qubits, "
-                   "but this gate has "
-                << itr.size() << " qubits." << std::endl;
+            std::stringstream ss;
+            ss << "Error: "
+                  "QuantumCircuit::add_noise_gate(QuantumGateBase*,string,"
+                  "double) : AmplitudeDamping noise can be used by 1 qubits, "
+                  "but this gate has "
+               << itr.size() << " qubits.";
+            throw std::invalid_argument(ss.str());
         }
     } else {
-        std::cerr << "Error: "
-                     "QuantumCircuit::add_noise_gate(QuantumGateBase*,string,"
-                     "double) : noise_type is undetectable. your noise_type = '"
-                  << noise_type << "'." << std::endl;
+        std::stringstream ss;
+        ss << "Error: "
+              "QuantumCircuit::add_noise_gate(QuantumGateBase*,string,"
+              "double) : noise_type is undetectable. your noise_type = '"
+           << noise_type << "'.";
+        throw std::invalid_argument(ss.str());
     }
 }
 
@@ -220,10 +225,10 @@ void QuantumCircuit::add_noise_gate_copy(
 
 void QuantumCircuit::remove_gate(UINT index) {
     if (index >= this->_gate_list.size()) {
-        std::cerr << "Error: QuantumCircuit::remove_gate(UINT) : index must be "
-                     "smaller than gate_count"
-                  << std::endl;
-        return;
+        std::stringstream ss;
+        ss << "Error: QuantumCircuit::remove_gate(UINT) : index must be "
+              "smaller than gate_count";
+        throw std::invalid_argument(ss.str());
     }
     delete this->_gate_list[index];
     this->_gate_list.erase(this->_gate_list.begin() + index);
@@ -280,8 +285,8 @@ std::string QuantumCircuit::to_string() const {
     UINT max_block_size = 0;
 
     for (const auto gate : this->_gate_list) {
-        UINT whole_qubit_index_count = (UINT)(
-            gate->target_qubit_list.size() + gate->control_qubit_list.size());
+        UINT whole_qubit_index_count = (UINT)(gate->target_qubit_list.size() +
+                                              gate->control_qubit_list.size());
         if (whole_qubit_index_count == 0) continue;
         gate_size_count[whole_qubit_index_count - 1]++;
         max_block_size = std::max(max_block_size, whole_qubit_index_count);
@@ -399,11 +404,11 @@ void QuantumCircuit::add_multi_Pauli_rotation_gate(
     const PauliOperator& pauli_operator) {
     const double eps = 1e-14;
     if (std::abs(pauli_operator.get_coef().imag()) > eps) {
-        std::cerr
-            << "Error: QuantumCircuit::add_multi_Pauli_rotation_gate(const "
-               "PauliOperator& pauli_operator): not impremented for non "
-               "hermitian"
-            << std::endl;
+        std::stringstream ss;
+        ss << "Error: QuantumCircuit::add_multi_Pauli_rotation_gate(const "
+              "PauliOperator& pauli_operator): not impremented for non "
+              "hermitian";
+        throw std::invalid_argument(ss.str());
     }
     this->add_gate(gate::PauliRotation(pauli_operator.get_index_list(),
         pauli_operator.get_pauli_id_list(), pauli_operator.get_coef().real()));
@@ -411,20 +416,20 @@ void QuantumCircuit::add_multi_Pauli_rotation_gate(
 void QuantumCircuit::add_diagonal_observable_rotation_gate(
     const Observable& observable, double angle) {
     if (!observable.is_hermitian()) {
-        std::cerr
-            << "Error: QuantumCircuit::add_observable_rotation_gate(const "
-               "Observable& observable, double angle, UINT num_repeats): not "
-               "impremented for non hermitian"
-            << std::endl;
-        return;
+        std::stringstream ss;
+        ss << "Error: QuantumCircuit::add_observable_rotation_gate(const "
+              "Observable& observable, double angle, UINT num_repeats): not "
+              "impremented for non hermitian";
+        throw std::invalid_argument(ss.str());
     }
     std::vector<PauliOperator*> operator_list = observable.get_terms();
     for (auto pauli : operator_list) {
         auto pauli_rotation = gate::PauliRotation(pauli->get_index_list(),
             pauli->get_pauli_id_list(), pauli->get_coef().real() * angle);
         if (!pauli_rotation->is_diagonal()) {
-            std::cerr << "ERROR: Observable is not diagonal" << std::endl;
-            return;
+            std::stringstream ss;
+            ss << "ERROR: Observable is not diagonal";
+            throw std::invalid_argument(ss.str());
         }
         this->add_gate(pauli_rotation);
     }
@@ -432,12 +437,11 @@ void QuantumCircuit::add_diagonal_observable_rotation_gate(
 void QuantumCircuit::add_observable_rotation_gate(
     const Observable& observable, double angle, UINT num_repeats) {
     if (!observable.is_hermitian()) {
-        std::cerr
-            << "Error: QuantumCircuit::add_observable_rotation_gate(const "
-               "Observable& observable, double angle, UINT num_repeats): not "
-               "impremented for non hermitian"
-            << std::endl;
-        return;
+        std::stringstream ss;
+        ss << "Error: QuantumCircuit::add_observable_rotation_gate(const "
+              "Observable& observable, double angle, UINT num_repeats): not "
+              "impremented for non hermitian";
+        throw std::invalid_argument(ss.str());
     }
     UINT qubit_count_ = observable.get_qubit_count();
     std::vector<PauliOperator*> operator_list = observable.get_terms();
@@ -456,12 +460,12 @@ void QuantumCircuit::add_observable_rotation_gate(
 void QuantumCircuit::add_dense_matrix_gate(
     UINT target_index, const ComplexMatrix& matrix) {
     if (matrix.cols() != 2 || matrix.rows() != 2) {
-        std::cerr << "Error: add_dense_matrix_gate(UINT, const ComplexMatrix&) "
-                     ": matrix "
-                     "must be matrix.cols()==2 and matrix.rows()==2 for single "
-                     "qubit gate"
-                  << std::endl;
-        return;
+        std::stringstream ss;
+        ss << "Error: add_dense_matrix_gate(UINT, const ComplexMatrix&) "
+              ": matrix "
+              "must be matrix.cols()==2 and matrix.rows()==2 for single "
+              "qubit gate";
+        throw std::invalid_argument(ss.str());
     }
 
     this->add_gate(gate::DenseMatrix(target_index, matrix));
@@ -470,12 +474,12 @@ void QuantumCircuit::add_dense_matrix_gate(
     std::vector<UINT> target_index_list, const ComplexMatrix& matrix) {
     if (matrix.cols() != (1LL << target_index_list.size()) ||
         matrix.rows() != (1LL << target_index_list.size())) {
-        std::cerr << "Error: add_dense_matrix_gate(vector<UINT>, const "
-                     "ComplexMatrix&) : "
-                     "matrix must be matrix.cols()==(1<<target_count) and "
-                     "matrix.rows()==(1<<target_count)"
-                  << std::endl;
-        return;
+        std::stringstream ss;
+        ss << "Error: add_dense_matrix_gate(vector<UINT>, const "
+              "ComplexMatrix&) : "
+              "matrix must be matrix.cols()==(1<<target_count) and "
+              "matrix.rows()==(1<<target_count)";
+        throw std::invalid_argument(ss.str());
     }
 
     this->add_gate(gate::DenseMatrix(target_index_list, matrix));

--- a/src/cppsim/circuit.cpp
+++ b/src/cppsim/circuit.cpp
@@ -285,8 +285,8 @@ std::string QuantumCircuit::to_string() const {
     UINT max_block_size = 0;
 
     for (const auto gate : this->_gate_list) {
-        UINT whole_qubit_index_count = (UINT)(gate->target_qubit_list.size() +
-                                              gate->control_qubit_list.size());
+        UINT whole_qubit_index_count = (UINT)(
+            gate->target_qubit_list.size() + gate->control_qubit_list.size());
         if (whole_qubit_index_count == 0) continue;
         gate_size_count[whole_qubit_index_count - 1]++;
         max_block_size = std::max(max_block_size, whole_qubit_index_count);

--- a/src/cppsim/circuit.cpp
+++ b/src/cppsim/circuit.cpp
@@ -21,11 +21,12 @@ bool check_gate_index(
 
 void QuantumCircuit::update_quantum_state(QuantumStateBase* state) {
     if (state->qubit_count != this->qubit_count) {
-        std::stringstream ss;
-        ss << "Error: "
-              "QuantumCircuit::update_quantum_state(QuantumStateBase) : "
-              "invalid qubit count";
-        throw std::invalid_argument(ss.str());
+        std::stringstream error_message_stream;
+        error_message_stream
+            << "Error: "
+               "QuantumCircuit::update_quantum_state(QuantumStateBase) : "
+               "invalid qubit count";
+        throw std::invalid_argument(error_message_stream.str());
     }
 
     for (const auto& gate : this->_gate_list) {
@@ -36,25 +37,28 @@ void QuantumCircuit::update_quantum_state(QuantumStateBase* state) {
 void QuantumCircuit::update_quantum_state(
     QuantumStateBase* state, UINT start, UINT end) {
     if (state->qubit_count != this->qubit_count) {
-        std::stringstream ss;
-        ss << "Error: "
-              "QuantumCircuit::update_quantum_state(QuantumStateBase,UINT,"
-              "UINT) : invalid qubit count";
-        throw std::invalid_argument(ss.str());
+        std::stringstream error_message_stream;
+        error_message_stream
+            << "Error: "
+               "QuantumCircuit::update_quantum_state(QuantumStateBase,UINT,"
+               "UINT) : invalid qubit count";
+        throw std::invalid_argument(error_message_stream.str());
     }
     if (start > end) {
-        std::stringstream ss;
-        ss << "Error: "
-              "QuantumCircuit::update_quantum_state(QuantumStateBase,UINT,"
-              "UINT) : start must be smaller than or equal to end";
-        throw std::invalid_argument(ss.str());
+        std::stringstream error_message_stream;
+        error_message_stream
+            << "Error: "
+               "QuantumCircuit::update_quantum_state(QuantumStateBase,UINT,"
+               "UINT) : start must be smaller than or equal to end";
+        throw std::invalid_argument(error_message_stream.str());
     }
     if (end > this->_gate_list.size()) {
-        std::stringstream ss;
-        ss << "Error: "
-              "QuantumCircuit::update_quantum_state(QuantumStateBase,UINT,"
-              "UINT) : end must be smaller than or equal to gate_count";
-        throw std::invalid_argument(ss.str());
+        std::stringstream error_message_stream;
+        error_message_stream
+            << "Error: "
+               "QuantumCircuit::update_quantum_state(QuantumStateBase,UINT,"
+               "UINT) : end must be smaller than or equal to gate_count";
+        throw std::invalid_argument(error_message_stream.str());
     }
     for (UINT cursor = start; cursor < end; ++cursor) {
         this->_gate_list[cursor]->update_quantum_state(state);
@@ -99,29 +103,32 @@ bool check_gate_index(
 
 void QuantumCircuit::add_gate(QuantumGateBase* gate) {
     if (!check_gate_index(this, gate)) {
-        std::stringstream ss;
-        ss << "Error: QuatnumCircuit::add_gate(QuantumGateBase*): gate "
-              "must be "
-              "applied to qubits of which the indices are smaller than "
-              "qubit_count";
-        throw std::invalid_argument(ss.str());
+        std::stringstream error_message_stream;
+        error_message_stream
+            << "Error: QuatnumCircuit::add_gate(QuantumGateBase*): gate "
+               "must be "
+               "applied to qubits of which the indices are smaller than "
+               "qubit_count";
+        throw std::invalid_argument(error_message_stream.str());
     }
     this->_gate_list.push_back(gate);
 }
 
 void QuantumCircuit::add_gate(QuantumGateBase* gate, UINT index) {
     if (!check_gate_index(this, gate)) {
-        std::stringstream ss;
-        ss << "Error: QuatnumCircuit::add_gate(QuantumGateBase*, UINT): "
-              "gate must be applied to qubits of which the indices are "
-              "smaller than qubit_count";
-        throw std::invalid_argument(ss.str());
+        std::stringstream error_message_stream;
+        error_message_stream
+            << "Error: QuatnumCircuit::add_gate(QuantumGateBase*, UINT): "
+               "gate must be applied to qubits of which the indices are "
+               "smaller than qubit_count";
+        throw std::invalid_argument(error_message_stream.str());
     }
     if (index > this->_gate_list.size()) {
-        std::stringstream ss;
-        ss << "Error: QuantumCircuit::add_gate(QuantumGateBase*, UINT) : "
-              "insert index must be smaller than or equal to gate_count";
-        throw std::invalid_argument(ss.str());
+        std::stringstream error_message_stream;
+        error_message_stream
+            << "Error: QuantumCircuit::add_gate(QuantumGateBase*, UINT) : "
+               "insert index must be smaller than or equal to gate_count";
+        throw std::invalid_argument(error_message_stream.str());
     }
     this->_gate_list.insert(this->_gate_list.begin() + index, gate);
 }
@@ -150,71 +157,77 @@ void QuantumCircuit::add_noise_gate(
             this->add_gate(
                 gate::TwoQubitDepolarizingNoise(itr[0], itr[1], noise_prob));
         } else {
-            std::stringstream ss;
-            ss << "Error: "
-                  "QuantumCircuit::add_noise_gate(QuantumGateBase*,"
-                  "string,double) : "
-                  "depolarizing noise can be used up to 2 qubits, but "
-                  "this gate has "
-               << itr.size() << " qubits.";
-            throw std::invalid_argument(ss.str());
+            std::stringstream error_message_stream;
+            error_message_stream
+                << "Error: "
+                   "QuantumCircuit::add_noise_gate(QuantumGateBase*,"
+                   "string,double) : "
+                   "depolarizing noise can be used up to 2 qubits, but "
+                   "this gate has "
+                << itr.size() << " qubits.";
+            throw std::invalid_argument(error_message_stream.str());
         }
     } else if (noise_type == "BitFlip") {
         if (itr.size() == 1) {
             this->add_gate(gate::BitFlipNoise(itr[0], noise_prob));
         } else {
-            std::stringstream ss;
-            ss << "Error: "
-                  "QuantumCircuit::add_noise_gate(QuantumGateBase*,string,"
-                  "double) : "
-                  "BitFlip noise can be used by 1 qubits, but this gate has "
-               << itr.size() << " qubits.";
-            throw std::invalid_argument(ss.str());
+            std::stringstream error_message_stream;
+            error_message_stream
+                << "Error: "
+                   "QuantumCircuit::add_noise_gate(QuantumGateBase*,string,"
+                   "double) : "
+                   "BitFlip noise can be used by 1 qubits, but this gate has "
+                << itr.size() << " qubits.";
+            throw std::invalid_argument(error_message_stream.str());
         }
     } else if (noise_type == "Dephasing") {
         if (itr.size() == 1) {
             this->add_gate(gate::DephasingNoise(itr[0], noise_prob));
         } else {
-            std::stringstream ss;
-            ss << "Error: "
-                  "QuantumCircuit::add_noise_gate(QuantumGateBase*,string,"
-                  "double) : "
-                  "Dephasing noise can be used by 1 qubits, but this gate has "
-               << itr.size() << " qubits.";
-            throw std::invalid_argument(ss.str());
+            std::stringstream error_message_stream;
+            error_message_stream
+                << "Error: "
+                   "QuantumCircuit::add_noise_gate(QuantumGateBase*,string,"
+                   "double) : "
+                   "Dephasing noise can be used by 1 qubits, but this gate has "
+                << itr.size() << " qubits.";
+            throw std::invalid_argument(error_message_stream.str());
         }
     } else if (noise_type == "IndependentXZ") {
         if (itr.size() == 1) {
             this->add_gate(gate::IndependentXZNoise(itr[0], noise_prob));
         } else {
-            std::stringstream ss;
-            ss << "Error: "
-                  "QuantumCircuit::add_noise_gate(QuantumGateBase*,"
-                  "string,double) : "
-                  "IndependentXZ noise can be used by 1 qubits, but "
-                  "this gate has "
-               << itr.size() << " qubits.";
-            throw std::invalid_argument(ss.str());
+            std::stringstream error_message_stream;
+            error_message_stream
+                << "Error: "
+                   "QuantumCircuit::add_noise_gate(QuantumGateBase*,"
+                   "string,double) : "
+                   "IndependentXZ noise can be used by 1 qubits, but "
+                   "this gate has "
+                << itr.size() << " qubits.";
+            throw std::invalid_argument(error_message_stream.str());
         }
     } else if (noise_type == "AmplitudeDamping") {
         if (itr.size() == 1) {
             this->add_gate(gate::AmplitudeDampingNoise(itr[0], noise_prob));
         } else {
-            std::stringstream ss;
-            ss << "Error: "
-                  "QuantumCircuit::add_noise_gate(QuantumGateBase*,string,"
-                  "double) : AmplitudeDamping noise can be used by 1 qubits, "
-                  "but this gate has "
-               << itr.size() << " qubits.";
-            throw std::invalid_argument(ss.str());
+            std::stringstream error_message_stream;
+            error_message_stream
+                << "Error: "
+                   "QuantumCircuit::add_noise_gate(QuantumGateBase*,string,"
+                   "double) : AmplitudeDamping noise can be used by 1 qubits, "
+                   "but this gate has "
+                << itr.size() << " qubits.";
+            throw std::invalid_argument(error_message_stream.str());
         }
     } else {
-        std::stringstream ss;
-        ss << "Error: "
-              "QuantumCircuit::add_noise_gate(QuantumGateBase*,string,"
-              "double) : noise_type is undetectable. your noise_type = '"
-           << noise_type << "'.";
-        throw std::invalid_argument(ss.str());
+        std::stringstream error_message_stream;
+        error_message_stream
+            << "Error: "
+               "QuantumCircuit::add_noise_gate(QuantumGateBase*,string,"
+               "double) : noise_type is undetectable. your noise_type = '"
+            << noise_type << "'.";
+        throw std::invalid_argument(error_message_stream.str());
     }
 }
 
@@ -225,10 +238,11 @@ void QuantumCircuit::add_noise_gate_copy(
 
 void QuantumCircuit::remove_gate(UINT index) {
     if (index >= this->_gate_list.size()) {
-        std::stringstream ss;
-        ss << "Error: QuantumCircuit::remove_gate(UINT) : index must be "
-              "smaller than gate_count";
-        throw std::invalid_argument(ss.str());
+        std::stringstream error_message_stream;
+        error_message_stream
+            << "Error: QuantumCircuit::remove_gate(UINT) : index must be "
+               "smaller than gate_count";
+        throw std::invalid_argument(error_message_stream.str());
     }
     delete this->_gate_list[index];
     this->_gate_list.erase(this->_gate_list.begin() + index);
@@ -404,11 +418,12 @@ void QuantumCircuit::add_multi_Pauli_rotation_gate(
     const PauliOperator& pauli_operator) {
     const double eps = 1e-14;
     if (std::abs(pauli_operator.get_coef().imag()) > eps) {
-        std::stringstream ss;
-        ss << "Error: QuantumCircuit::add_multi_Pauli_rotation_gate(const "
-              "PauliOperator& pauli_operator): not impremented for non "
-              "hermitian";
-        throw std::invalid_argument(ss.str());
+        std::stringstream error_message_stream;
+        error_message_stream
+            << "Error: QuantumCircuit::add_multi_Pauli_rotation_gate(const "
+               "PauliOperator& pauli_operator): not impremented for non "
+               "hermitian";
+        throw std::invalid_argument(error_message_stream.str());
     }
     this->add_gate(gate::PauliRotation(pauli_operator.get_index_list(),
         pauli_operator.get_pauli_id_list(), pauli_operator.get_coef().real()));
@@ -416,20 +431,21 @@ void QuantumCircuit::add_multi_Pauli_rotation_gate(
 void QuantumCircuit::add_diagonal_observable_rotation_gate(
     const Observable& observable, double angle) {
     if (!observable.is_hermitian()) {
-        std::stringstream ss;
-        ss << "Error: QuantumCircuit::add_observable_rotation_gate(const "
-              "Observable& observable, double angle, UINT num_repeats): not "
-              "impremented for non hermitian";
-        throw std::invalid_argument(ss.str());
+        std::stringstream error_message_stream;
+        error_message_stream
+            << "Error: QuantumCircuit::add_observable_rotation_gate(const "
+               "Observable& observable, double angle, UINT num_repeats): not "
+               "impremented for non hermitian";
+        throw std::invalid_argument(error_message_stream.str());
     }
     std::vector<PauliOperator*> operator_list = observable.get_terms();
     for (auto pauli : operator_list) {
         auto pauli_rotation = gate::PauliRotation(pauli->get_index_list(),
             pauli->get_pauli_id_list(), pauli->get_coef().real() * angle);
         if (!pauli_rotation->is_diagonal()) {
-            std::stringstream ss;
-            ss << "ERROR: Observable is not diagonal";
-            throw std::invalid_argument(ss.str());
+            std::stringstream error_message_stream;
+            error_message_stream << "ERROR: Observable is not diagonal";
+            throw std::invalid_argument(error_message_stream.str());
         }
         this->add_gate(pauli_rotation);
     }
@@ -437,11 +453,12 @@ void QuantumCircuit::add_diagonal_observable_rotation_gate(
 void QuantumCircuit::add_observable_rotation_gate(
     const Observable& observable, double angle, UINT num_repeats) {
     if (!observable.is_hermitian()) {
-        std::stringstream ss;
-        ss << "Error: QuantumCircuit::add_observable_rotation_gate(const "
-              "Observable& observable, double angle, UINT num_repeats): not "
-              "impremented for non hermitian";
-        throw std::invalid_argument(ss.str());
+        std::stringstream error_message_stream;
+        error_message_stream
+            << "Error: QuantumCircuit::add_observable_rotation_gate(const "
+               "Observable& observable, double angle, UINT num_repeats): not "
+               "impremented for non hermitian";
+        throw std::invalid_argument(error_message_stream.str());
     }
     UINT qubit_count_ = observable.get_qubit_count();
     std::vector<PauliOperator*> operator_list = observable.get_terms();
@@ -460,12 +477,13 @@ void QuantumCircuit::add_observable_rotation_gate(
 void QuantumCircuit::add_dense_matrix_gate(
     UINT target_index, const ComplexMatrix& matrix) {
     if (matrix.cols() != 2 || matrix.rows() != 2) {
-        std::stringstream ss;
-        ss << "Error: add_dense_matrix_gate(UINT, const ComplexMatrix&) "
-              ": matrix "
-              "must be matrix.cols()==2 and matrix.rows()==2 for single "
-              "qubit gate";
-        throw std::invalid_argument(ss.str());
+        std::stringstream error_message_stream;
+        error_message_stream
+            << "Error: add_dense_matrix_gate(UINT, const ComplexMatrix&) "
+               ": matrix "
+               "must be matrix.cols()==2 and matrix.rows()==2 for single "
+               "qubit gate";
+        throw std::invalid_argument(error_message_stream.str());
     }
 
     this->add_gate(gate::DenseMatrix(target_index, matrix));
@@ -474,12 +492,13 @@ void QuantumCircuit::add_dense_matrix_gate(
     std::vector<UINT> target_index_list, const ComplexMatrix& matrix) {
     if (matrix.cols() != (1LL << target_index_list.size()) ||
         matrix.rows() != (1LL << target_index_list.size())) {
-        std::stringstream ss;
-        ss << "Error: add_dense_matrix_gate(vector<UINT>, const "
-              "ComplexMatrix&) : "
-              "matrix must be matrix.cols()==(1<<target_count) and "
-              "matrix.rows()==(1<<target_count)";
-        throw std::invalid_argument(ss.str());
+        std::stringstream error_message_stream;
+        error_message_stream
+            << "Error: add_dense_matrix_gate(vector<UINT>, const "
+               "ComplexMatrix&) : "
+               "matrix must be matrix.cols()==(1<<target_count) and "
+               "matrix.rows()==(1<<target_count)";
+        throw std::invalid_argument(error_message_stream.str());
     }
 
     this->add_gate(gate::DenseMatrix(target_index_list, matrix));

--- a/src/cppsim/gate.cpp
+++ b/src/cppsim/gate.cpp
@@ -63,8 +63,7 @@ bool QuantumGateBase::commute_Pauli_at(
     UINT qubit_index, UINT pauli_type) const {
     if (pauli_type == 0) return true;
     if (pauli_type >= 4) {
-        fprintf(stderr, "invalid Pauli id is given\n");
-        assert(false);
+        throw std::invalid_argument("invalid Pauli id is given");
     }
     auto ite_target = std::find_if(this->_target_qubit_list.begin(),
         this->_target_qubit_list.end(),

--- a/src/cppsim/gate_factory.cpp
+++ b/src/cppsim/gate_factory.cpp
@@ -96,46 +96,50 @@ QuantumGateBase* U3(UINT qubit_index, double theta, double phi, double lambda) {
 
 QuantumGateBase* CNOT(UINT control_qubit_index, UINT target_qubit_index) {
     if (control_qubit_index == target_qubit_index) {
-        std::stringstream ss;
-        ss << "Error: gate::CNOT(UINT, UINT): control_qubit_index and "
-              "target_qubit_index has the same value."
-              "\nInfo: NULL used to be returned, "
-              "but it changed to throw exception.";
-        throw std::invalid_argument(ss.str());
+        std::stringstream error_message_stream;
+        error_message_stream
+            << "Error: gate::CNOT(UINT, UINT): control_qubit_index and "
+               "target_qubit_index has the same value."
+               "\nInfo: NULL used to be returned, "
+               "but it changed to throw exception.";
+        throw std::invalid_argument(error_message_stream.str());
     }
     return new ClsCNOTGate(control_qubit_index, target_qubit_index);
 }
 QuantumGateBase* CZ(UINT control_qubit_index, UINT target_qubit_index) {
     if (control_qubit_index == target_qubit_index) {
-        std::stringstream ss;
-        ss << "Error: gate::CZ(UINT, UINT): control_qubit_index and "
-              "target_qubit_index has the same value."
-              "\nInfo: NULL used to be returned, "
-              "but it changed to throw exception.";
-        throw std::invalid_argument(ss.str());
+        std::stringstream error_message_stream;
+        error_message_stream
+            << "Error: gate::CZ(UINT, UINT): control_qubit_index and "
+               "target_qubit_index has the same value."
+               "\nInfo: NULL used to be returned, "
+               "but it changed to throw exception.";
+        throw std::invalid_argument(error_message_stream.str());
     }
     return new ClsCZGate(control_qubit_index, target_qubit_index);
 }
 QuantumGateBase* SWAP(UINT qubit_index1, UINT qubit_index2) {
     if (qubit_index1 == qubit_index2) {
-        std::stringstream ss;
-        ss << "Error: gate::SWAP(UINT, UINT): two indices have the same value."
-              "\nInfo: NULL used to be returned, "
-              "but it changed to throw exception.";
-        throw std::invalid_argument(ss.str());
+        std::stringstream error_message_stream;
+        error_message_stream
+            << "Error: gate::SWAP(UINT, UINT): two indices have the same value."
+               "\nInfo: NULL used to be returned, "
+               "but it changed to throw exception.";
+        throw std::invalid_argument(error_message_stream.str());
     }
     return new ClsSWAPGate(qubit_index1, qubit_index2);
 }
 
 QuantumGateBase* Pauli(std::vector<UINT> target, std::vector<UINT> pauli_id) {
     if (!check_is_unique_index_list(target)) {
-        std::stringstream ss;
-        ss << "Error: gate::Pauli(std::vector<UINT> target, "
-              "std::vector<UINT>pauli_id): target list contains "
-              "duplicated values."
-              "\nInfo: NULL used to be returned, "
-              "but it changed to throw exception.";
-        throw std::invalid_argument(ss.str());
+        std::stringstream error_message_stream;
+        error_message_stream
+            << "Error: gate::Pauli(std::vector<UINT> target, "
+               "std::vector<UINT>pauli_id): target list contains "
+               "duplicated values."
+               "\nInfo: NULL used to be returned, "
+               "but it changed to throw exception.";
+        throw std::invalid_argument(error_message_stream.str());
     }
     auto pauli = new PauliOperator(target, pauli_id);
     return new ClsPauliGate(pauli);
@@ -143,13 +147,14 @@ QuantumGateBase* Pauli(std::vector<UINT> target, std::vector<UINT> pauli_id) {
 QuantumGateBase* PauliRotation(
     std::vector<UINT> target, std::vector<UINT> pauli_id, double angle) {
     if (!check_is_unique_index_list(target)) {
-        std::stringstream ss;
-        ss << "Error: gate::PauliRotation(std::vector<UINT> target, "
-              "std::vector<UINT>pauli_id, double angle): target list "
-              "contains duplicated values."
-              "\nInfo: NULL used to be returned, "
-              "but it changed to throw exception.";
-        throw std::invalid_argument(ss.str());
+        std::stringstream error_message_stream;
+        error_message_stream
+            << "Error: gate::PauliRotation(std::vector<UINT> target, "
+               "std::vector<UINT>pauli_id, double angle): target list "
+               "contains duplicated values."
+               "\nInfo: NULL used to be returned, "
+               "but it changed to throw exception.";
+        throw std::invalid_argument(error_message_stream.str());
     }
     auto pauli = new PauliOperator(target, pauli_id, angle);
     return new ClsPauliRotationGate(angle, pauli);
@@ -162,12 +167,13 @@ QuantumGateMatrix* DenseMatrix(UINT target_index, ComplexMatrix matrix) {
 QuantumGateMatrix* DenseMatrix(
     std::vector<UINT> target_list, ComplexMatrix matrix) {
     if (!check_is_unique_index_list(target_list)) {
-        std::stringstream ss;
-        ss << "Error: gate::DenseMatrix(std::vector<UINT> target_list, "
-              "ComplexMatrix matrix): target list contains duplicated values."
-              "\nInfo: NULL used to be returned, "
-              "but it changed to throw exception.";
-        throw std::invalid_argument(ss.str());
+        std::stringstream error_message_stream;
+        error_message_stream
+            << "Error: gate::DenseMatrix(std::vector<UINT> target_list, "
+               "ComplexMatrix matrix): target list contains duplicated values."
+               "\nInfo: NULL used to be returned, "
+               "but it changed to throw exception.";
+        throw std::invalid_argument(error_message_stream.str());
     }
     return new QuantumGateMatrix(target_list, matrix);
 }
@@ -175,38 +181,41 @@ QuantumGateMatrix* DenseMatrix(
 QuantumGateBase* SparseMatrix(
     std::vector<UINT> target_list, SparseComplexMatrix matrix) {
     if (!check_is_unique_index_list(target_list)) {
-        std::stringstream ss;
-        ss << "Error: gate::SparseMatrix(std::vector<UINT> target_list, "
-              "SparseComplexMatrix matrix): target list contains duplicated "
-              "values."
-              "\nInfo: NULL used to be returned, "
-              "but it changed to throw exception.";
-        throw std::invalid_argument(ss.str());
+        std::stringstream error_message_stream;
+        error_message_stream
+            << "Error: gate::SparseMatrix(std::vector<UINT> target_list, "
+               "SparseComplexMatrix matrix): target list contains duplicated "
+               "values."
+               "\nInfo: NULL used to be returned, "
+               "but it changed to throw exception.";
+        throw std::invalid_argument(error_message_stream.str());
     }
     return new QuantumGateSparseMatrix(target_list, matrix);
 }
 QuantumGateBase* DiagonalMatrix(
     std::vector<UINT> target_list, ComplexVector diagonal_element) {
     if (!check_is_unique_index_list(target_list)) {
-        std::stringstream ss;
-        ss << "Error: gate::DiagonalMatrix(std::vector<UINT> target_list, "
-              "ComplexVector diagonal_element): target list contains "
-              "duplicated values."
-              "\nInfo: NULL used to be returned, "
-              "but it changed to throw exception.";
-        throw std::invalid_argument(ss.str());
+        std::stringstream error_message_stream;
+        error_message_stream
+            << "Error: gate::DiagonalMatrix(std::vector<UINT> target_list, "
+               "ComplexVector diagonal_element): target list contains "
+               "duplicated values."
+               "\nInfo: NULL used to be returned, "
+               "but it changed to throw exception.";
+        throw std::invalid_argument(error_message_stream.str());
     }
     return new QuantumGateDiagonalMatrix(target_list, diagonal_element);
 }
 
 QuantumGateMatrix* RandomUnitary(std::vector<UINT> target_list) {
     if (!check_is_unique_index_list(target_list)) {
-        std::stringstream ss;
-        ss << "Error: gate::RandomUnitary(std::vector<UINT> target_list): "
-              "target list contains duplicated values."
-              "\nInfo: NULL used to be returned, "
-              "but it changed to throw exception.";
-        throw std::invalid_argument(ss.str());
+        std::stringstream error_message_stream;
+        error_message_stream
+            << "Error: gate::RandomUnitary(std::vector<UINT> target_list): "
+               "target list contains duplicated values."
+               "\nInfo: NULL used to be returned, "
+               "but it changed to throw exception.";
+        throw std::invalid_argument(error_message_stream.str());
     }
     Random random;
     UINT qubit_count = (UINT)target_list.size();
@@ -232,13 +241,14 @@ QuantumGateMatrix* RandomUnitary(std::vector<UINT> target_list) {
 QuantumGateBase* ReversibleBoolean(std::vector<UINT> target_qubit_index_list,
     std::function<ITYPE(ITYPE, ITYPE)> function_ptr) {
     if (!check_is_unique_index_list(target_qubit_index_list)) {
-        std::stringstream ss;
-        ss << "Error: gate::ReversibleBoolean(std::vector<UINT> "
-              "target_qubit_index_list, std::function<ITYPE(ITYPE,ITYPE)> "
-              "function_ptr): target list contains duplicated values."
-              "\nInfo: NULL used to be returned, "
-              "but it changed to throw exception.";
-        throw std::invalid_argument(ss.str());
+        std::stringstream error_message_stream;
+        error_message_stream
+            << "Error: gate::ReversibleBoolean(std::vector<UINT> "
+               "target_qubit_index_list, std::function<ITYPE(ITYPE,ITYPE)> "
+               "function_ptr): target list contains duplicated values."
+               "\nInfo: NULL used to be returned, "
+               "but it changed to throw exception.";
+        throw std::invalid_argument(error_message_stream.str());
     }
     return new ClsReversibleBooleanGate(target_qubit_index_list, function_ptr);
 }
@@ -294,12 +304,13 @@ QuantumGateBase* DepolarizingNoise(UINT target_index, double prob) {
 QuantumGateBase* TwoQubitDepolarizingNoise(
     UINT target_index1, UINT target_index2, double prob) {
     if (target_index1 == target_index2) {
-        std::stringstream ss;
-        ss << "Error: gate::TwoQubitDepolarizingNoise(UINT, UINT, double): "
-              "target list contains duplicated values."
-              "\nInfo: NULL used to be returned, "
-              "but it changed to throw exception.";
-        throw std::invalid_argument(ss.str());
+        std::stringstream error_message_stream;
+        error_message_stream
+            << "Error: gate::TwoQubitDepolarizingNoise(UINT, UINT, double): "
+               "target list contains duplicated values."
+               "\nInfo: NULL used to be returned, "
+               "but it changed to throw exception.";
+        throw std::invalid_argument(error_message_stream.str());
     }
     std::vector<QuantumGateBase*> gate_list;
     for (int i = 0; i < 16; ++i) {

--- a/src/cppsim/gate_factory.cpp
+++ b/src/cppsim/gate_factory.cpp
@@ -96,39 +96,38 @@ QuantumGateBase* U3(UINT qubit_index, double theta, double phi, double lambda) {
 
 QuantumGateBase* CNOT(UINT control_qubit_index, UINT target_qubit_index) {
     if (control_qubit_index == target_qubit_index) {
-        std::cerr << "Error: gate::CNOT(UINT, UINT): control_qubit_index and "
-                     "target_qubit_index has the same value."
-                  << std::endl;
-        return NULL;
+        std::stringstream ss;
+        ss << "Error: gate::CNOT(UINT, UINT): control_qubit_index and "
+              "target_qubit_index has the same value.";
+        throw std::invalid_argument(ss.str());
     }
     return new ClsCNOTGate(control_qubit_index, target_qubit_index);
 }
 QuantumGateBase* CZ(UINT control_qubit_index, UINT target_qubit_index) {
     if (control_qubit_index == target_qubit_index) {
-        std::cerr << "Error: gate::CZ(UINT, UINT): control_qubit_index and "
-                     "target_qubit_index has the same value."
-                  << std::endl;
-        return NULL;
+        std::stringstream ss;
+        ss << "Error: gate::CZ(UINT, UINT): control_qubit_index and "
+              "target_qubit_index has the same value.";
+        throw std::invalid_argument(ss.str());
     }
     return new ClsCZGate(control_qubit_index, target_qubit_index);
 }
 QuantumGateBase* SWAP(UINT qubit_index1, UINT qubit_index2) {
     if (qubit_index1 == qubit_index2) {
-        std::cerr
-            << "Error: gate::SWAP(UINT, UINT): two indices have the same value."
-            << std::endl;
-        return NULL;
+        std::stringstream ss;
+        ss << "Error: gate::SWAP(UINT, UINT): two indices have the same value.";
+        throw std::invalid_argument(ss.str());
     }
     return new ClsSWAPGate(qubit_index1, qubit_index2);
 }
 
 QuantumGateBase* Pauli(std::vector<UINT> target, std::vector<UINT> pauli_id) {
     if (!check_is_unique_index_list(target)) {
-        std::cerr << "Error: gate::Pauli(std::vector<UINT> target, "
-                     "std::vector<UINT>pauli_id): target list contains "
-                     "duplicated values."
-                  << std::endl;
-        return NULL;
+        std::stringstream ss;
+        ss << "Error: gate::Pauli(std::vector<UINT> target, "
+              "std::vector<UINT>pauli_id): target list contains "
+              "duplicated values.";
+        throw std::invalid_argument(ss.str());
     }
     auto pauli = new PauliOperator(target, pauli_id);
     return new ClsPauliGate(pauli);
@@ -136,11 +135,11 @@ QuantumGateBase* Pauli(std::vector<UINT> target, std::vector<UINT> pauli_id) {
 QuantumGateBase* PauliRotation(
     std::vector<UINT> target, std::vector<UINT> pauli_id, double angle) {
     if (!check_is_unique_index_list(target)) {
-        std::cerr << "Error: gate::PauliRotation(std::vector<UINT> target, "
-                     "std::vector<UINT>pauli_id, double angle): target list "
-                     "contains duplicated values."
-                  << std::endl;
-        return NULL;
+        std::stringstream ss;
+        ss << "Error: gate::PauliRotation(std::vector<UINT> target, "
+              "std::vector<UINT>pauli_id, double angle): target list "
+              "contains duplicated values.";
+        throw std::invalid_argument(ss.str());
     }
     auto pauli = new PauliOperator(target, pauli_id, angle);
     return new ClsPauliRotationGate(angle, pauli);
@@ -153,11 +152,10 @@ QuantumGateMatrix* DenseMatrix(UINT target_index, ComplexMatrix matrix) {
 QuantumGateMatrix* DenseMatrix(
     std::vector<UINT> target_list, ComplexMatrix matrix) {
     if (!check_is_unique_index_list(target_list)) {
-        std::cerr
-            << "Error: gate::DenseMatrix(std::vector<UINT> target_list, "
-               "ComplexMatrix matrix): target list contains duplicated values."
-            << std::endl;
-        return NULL;
+        std::stringstream ss;
+        ss << "Error: gate::DenseMatrix(std::vector<UINT> target_list, "
+              "ComplexMatrix matrix): target list contains duplicated values.";
+        throw std::invalid_argument(ss.str());
     }
     return new QuantumGateMatrix(target_list, matrix);
 }
@@ -165,35 +163,32 @@ QuantumGateMatrix* DenseMatrix(
 QuantumGateBase* SparseMatrix(
     std::vector<UINT> target_list, SparseComplexMatrix matrix) {
     if (!check_is_unique_index_list(target_list)) {
-        std::cerr
-            << "Error: gate::SparseMatrix(std::vector<UINT> target_list, "
-               "SparseComplexMatrix matrix): target list contains duplicated "
-               "values."
-            << std::endl;
-        return NULL;
+        std::stringstream ss;
+        ss << "Error: gate::SparseMatrix(std::vector<UINT> target_list, "
+              "SparseComplexMatrix matrix): target list contains duplicated "
+              "values.";
+        throw std::invalid_argument(ss.str());
     }
     return new QuantumGateSparseMatrix(target_list, matrix);
 }
 QuantumGateBase* DiagonalMatrix(
     std::vector<UINT> target_list, ComplexVector diagonal_element) {
     if (!check_is_unique_index_list(target_list)) {
-        std::cerr
-            << "Error: gate::DiagonalMatrix(std::vector<UINT> target_list, "
-               "ComplexVector diagonal_element): target list contains "
-               "duplicated values."
-            << std::endl;
-        return NULL;
+        std::stringstream ss;
+        ss << "Error: gate::DiagonalMatrix(std::vector<UINT> target_list, "
+              "ComplexVector diagonal_element): target list contains "
+              "duplicated values.";
+        throw std::invalid_argument(ss.str());
     }
     return new QuantumGateDiagonalMatrix(target_list, diagonal_element);
 }
 
 QuantumGateMatrix* RandomUnitary(std::vector<UINT> target_list) {
     if (!check_is_unique_index_list(target_list)) {
-        std::cerr
-            << "Error: gate::RandomUnitary(std::vector<UINT> target_list): "
-               "target list contains duplicated values."
-            << std::endl;
-        return NULL;
+        std::stringstream ss;
+        ss << "Error: gate::RandomUnitary(std::vector<UINT> target_list): "
+              "target list contains duplicated values.";
+        throw std::invalid_argument(ss.str());
     }
     Random random;
     UINT qubit_count = (UINT)target_list.size();
@@ -219,12 +214,11 @@ QuantumGateMatrix* RandomUnitary(std::vector<UINT> target_list) {
 QuantumGateBase* ReversibleBoolean(std::vector<UINT> target_qubit_index_list,
     std::function<ITYPE(ITYPE, ITYPE)> function_ptr) {
     if (!check_is_unique_index_list(target_qubit_index_list)) {
-        std::cerr
-            << "Error: gate::ReversibleBoolean(std::vector<UINT> "
-               "target_qubit_index_list, std::function<ITYPE(ITYPE,ITYPE)> "
-               "function_ptr): target list contains duplicated values."
-            << std::endl;
-        return NULL;
+        std::stringstream ss;
+        ss << "Error: gate::ReversibleBoolean(std::vector<UINT> "
+              "target_qubit_index_list, std::function<ITYPE(ITYPE,ITYPE)> "
+              "function_ptr): target list contains duplicated values.";
+        throw std::invalid_argument(ss.str());
     }
     return new ClsReversibleBooleanGate(target_qubit_index_list, function_ptr);
 }
@@ -280,11 +274,10 @@ QuantumGateBase* DepolarizingNoise(UINT target_index, double prob) {
 QuantumGateBase* TwoQubitDepolarizingNoise(
     UINT target_index1, UINT target_index2, double prob) {
     if (target_index1 == target_index2) {
-        std::cerr
-            << "Error: gate::TwoQubitDepolarizingNoise(UINT, UINT, double): "
-               "target list contains duplicated values."
-            << std::endl;
-        return NULL;
+        std::stringstream ss;
+        ss << "Error: gate::TwoQubitDepolarizingNoise(UINT, UINT, double): "
+              "target list contains duplicated values.";
+        throw std::invalid_argument(ss.str());
     }
     std::vector<QuantumGateBase*> gate_list;
     for (int i = 0; i < 16; ++i) {

--- a/src/cppsim/gate_factory.cpp
+++ b/src/cppsim/gate_factory.cpp
@@ -98,7 +98,9 @@ QuantumGateBase* CNOT(UINT control_qubit_index, UINT target_qubit_index) {
     if (control_qubit_index == target_qubit_index) {
         std::stringstream ss;
         ss << "Error: gate::CNOT(UINT, UINT): control_qubit_index and "
-              "target_qubit_index has the same value.";
+              "target_qubit_index has the same value."
+              "\nInfo: NULL used to be returned, "
+              "but it changed to throw exception.";
         throw std::invalid_argument(ss.str());
     }
     return new ClsCNOTGate(control_qubit_index, target_qubit_index);
@@ -107,7 +109,9 @@ QuantumGateBase* CZ(UINT control_qubit_index, UINT target_qubit_index) {
     if (control_qubit_index == target_qubit_index) {
         std::stringstream ss;
         ss << "Error: gate::CZ(UINT, UINT): control_qubit_index and "
-              "target_qubit_index has the same value.";
+              "target_qubit_index has the same value."
+              "\nInfo: NULL used to be returned, "
+              "but it changed to throw exception.";
         throw std::invalid_argument(ss.str());
     }
     return new ClsCZGate(control_qubit_index, target_qubit_index);
@@ -115,7 +119,9 @@ QuantumGateBase* CZ(UINT control_qubit_index, UINT target_qubit_index) {
 QuantumGateBase* SWAP(UINT qubit_index1, UINT qubit_index2) {
     if (qubit_index1 == qubit_index2) {
         std::stringstream ss;
-        ss << "Error: gate::SWAP(UINT, UINT): two indices have the same value.";
+        ss << "Error: gate::SWAP(UINT, UINT): two indices have the same value."
+              "\nInfo: NULL used to be returned, "
+              "but it changed to throw exception.";
         throw std::invalid_argument(ss.str());
     }
     return new ClsSWAPGate(qubit_index1, qubit_index2);
@@ -126,7 +132,9 @@ QuantumGateBase* Pauli(std::vector<UINT> target, std::vector<UINT> pauli_id) {
         std::stringstream ss;
         ss << "Error: gate::Pauli(std::vector<UINT> target, "
               "std::vector<UINT>pauli_id): target list contains "
-              "duplicated values.";
+              "duplicated values."
+              "\nInfo: NULL used to be returned, "
+              "but it changed to throw exception.";
         throw std::invalid_argument(ss.str());
     }
     auto pauli = new PauliOperator(target, pauli_id);
@@ -138,7 +146,9 @@ QuantumGateBase* PauliRotation(
         std::stringstream ss;
         ss << "Error: gate::PauliRotation(std::vector<UINT> target, "
               "std::vector<UINT>pauli_id, double angle): target list "
-              "contains duplicated values.";
+              "contains duplicated values."
+              "\nInfo: NULL used to be returned, "
+              "but it changed to throw exception.";
         throw std::invalid_argument(ss.str());
     }
     auto pauli = new PauliOperator(target, pauli_id, angle);
@@ -154,7 +164,9 @@ QuantumGateMatrix* DenseMatrix(
     if (!check_is_unique_index_list(target_list)) {
         std::stringstream ss;
         ss << "Error: gate::DenseMatrix(std::vector<UINT> target_list, "
-              "ComplexMatrix matrix): target list contains duplicated values.";
+              "ComplexMatrix matrix): target list contains duplicated values."
+              "\nInfo: NULL used to be returned, "
+              "but it changed to throw exception.";
         throw std::invalid_argument(ss.str());
     }
     return new QuantumGateMatrix(target_list, matrix);
@@ -166,7 +178,9 @@ QuantumGateBase* SparseMatrix(
         std::stringstream ss;
         ss << "Error: gate::SparseMatrix(std::vector<UINT> target_list, "
               "SparseComplexMatrix matrix): target list contains duplicated "
-              "values.";
+              "values."
+              "\nInfo: NULL used to be returned, "
+              "but it changed to throw exception.";
         throw std::invalid_argument(ss.str());
     }
     return new QuantumGateSparseMatrix(target_list, matrix);
@@ -187,7 +201,9 @@ QuantumGateMatrix* RandomUnitary(std::vector<UINT> target_list) {
     if (!check_is_unique_index_list(target_list)) {
         std::stringstream ss;
         ss << "Error: gate::RandomUnitary(std::vector<UINT> target_list): "
-              "target list contains duplicated values.";
+              "target list contains duplicated values."
+              "\nInfo: NULL used to be returned, "
+              "but it changed to throw exception.";
         throw std::invalid_argument(ss.str());
     }
     Random random;
@@ -217,7 +233,9 @@ QuantumGateBase* ReversibleBoolean(std::vector<UINT> target_qubit_index_list,
         std::stringstream ss;
         ss << "Error: gate::ReversibleBoolean(std::vector<UINT> "
               "target_qubit_index_list, std::function<ITYPE(ITYPE,ITYPE)> "
-              "function_ptr): target list contains duplicated values.";
+              "function_ptr): target list contains duplicated values."
+              "\nInfo: NULL used to be returned, "
+              "but it changed to throw exception.";
         throw std::invalid_argument(ss.str());
     }
     return new ClsReversibleBooleanGate(target_qubit_index_list, function_ptr);
@@ -276,7 +294,9 @@ QuantumGateBase* TwoQubitDepolarizingNoise(
     if (target_index1 == target_index2) {
         std::stringstream ss;
         ss << "Error: gate::TwoQubitDepolarizingNoise(UINT, UINT, double): "
-              "target list contains duplicated values.";
+              "target list contains duplicated values."
+              "\nInfo: NULL used to be returned, "
+              "but it changed to throw exception.";
         throw std::invalid_argument(ss.str());
     }
     std::vector<QuantumGateBase*> gate_list;

--- a/src/cppsim/gate_matrix_sparse.cpp
+++ b/src/cppsim/gate_matrix_sparse.cpp
@@ -70,9 +70,10 @@ void QuantumGateSparseMatrix::update_quantum_state(QuantumStateBase* state) {
     ITYPE dim = 1ULL << state->qubit_count;
 
     if (this->_control_qubit_list.size() > 0) {
-        std::stringstream ss;
-        ss << "Control qubit in sparse matrix gate is not supported";
-        throw std::invalid_argument(ss.str());
+        std::stringstream error_message_stream;
+        error_message_stream
+            << "Control qubit in sparse matrix gate is not supported";
+        throw std::invalid_argument(error_message_stream.str());
     }
 
     std::vector<UINT> target_index;
@@ -83,9 +84,10 @@ void QuantumGateSparseMatrix::update_quantum_state(QuantumStateBase* state) {
     if (state->is_state_vector()) {
 #ifdef _USE_GPU
         if (state->get_device_name() == "gpu") {
-            std::stringstream ss;
-            ss << "Sparse matrix gate is not supported on GPU";
-            throw std::invalid_argument(ss.str());
+            std::stringstream error_message_stream;
+            error_message_stream
+                << "Sparse matrix gate is not supported on GPU";
+            throw std::invalid_argument(error_message_stream.str());
         } else {
             multi_qubit_sparse_matrix_gate_eigen(target_index.data(),
                 (UINT)(target_index.size()), this->_matrix_element,
@@ -97,9 +99,9 @@ void QuantumGateSparseMatrix::update_quantum_state(QuantumStateBase* state) {
             dim);
 #endif
     } else {
-        std::stringstream ss;
-        ss << "not implemented";
-        throw std::invalid_argument(ss.str());
+        std::stringstream error_message_stream;
+        error_message_stream << "not implemented";
+        throw std::invalid_argument(error_message_stream.str());
     }
 }
 

--- a/src/cppsim/gate_matrix_sparse.cpp
+++ b/src/cppsim/gate_matrix_sparse.cpp
@@ -70,8 +70,9 @@ void QuantumGateSparseMatrix::update_quantum_state(QuantumStateBase* state) {
     ITYPE dim = 1ULL << state->qubit_count;
 
     if (this->_control_qubit_list.size() > 0) {
-        std::cerr << "Control qubit in sparse matrix gate is not supported"
-                  << std::endl;
+        std::stringstream ss;
+        ss << "Control qubit in sparse matrix gate is not supported";
+        throw std::invalid_argument(ss.str());
     }
 
     std::vector<UINT> target_index;
@@ -82,8 +83,9 @@ void QuantumGateSparseMatrix::update_quantum_state(QuantumStateBase* state) {
     if (state->is_state_vector()) {
 #ifdef _USE_GPU
         if (state->get_device_name() == "gpu") {
-            std::cerr << "Sparse matrix gate is not supported on GPU"
-                      << std::endl;
+            std::stringstream ss;
+            ss << "Sparse matrix gate is not supported on GPU";
+            throw std::invalid_argument(ss.str());
         } else {
             multi_qubit_sparse_matrix_gate_eigen(target_index.data(),
                 (UINT)(target_index.size()), this->_matrix_element,
@@ -95,7 +97,9 @@ void QuantumGateSparseMatrix::update_quantum_state(QuantumStateBase* state) {
             dim);
 #endif
     } else {
-        std::cerr << "not implemented" << std::endl;
+        std::stringstream ss;
+        ss << "not implemented";
+        throw std::invalid_argument(ss.str());
     }
 }
 

--- a/src/cppsim/gate_reflect.hpp
+++ b/src/cppsim/gate_reflect.hpp
@@ -41,15 +41,16 @@ public:
 #ifdef _USE_GPU
             if (state->get_device_name() !=
                 reflection_state->get_device_name()) {
-                std::stringstream ss;
-                ss << "Quantum state on CPU (GPU) cannot be reflected using "
-                      "quantum state on GPU (CPU)";
-                throw std::invalid_argument(ss.str());
+                std::stringstream error_message_stream;
+                error_message_stream
+                    << "Quantum state on CPU (GPU) cannot be reflected using "
+                       "quantum state on GPU (CPU)";
+                throw std::invalid_argument(error_message_stream.str());
             }
             if (state->get_device_name() == "gpu") {
-                std::stringstream ss;
-                ss << "Not Implemented";
-                throw std::invalid_argument(ss.str());
+                std::stringstream error_message_stream;
+                error_message_stream << "Not Implemented";
+                throw std::invalid_argument(error_message_stream.str());
                 // reversible_boolean_gate_gpu(target_index.data(),
                 // target_index.size(), function_ptr, state->data_c(),
                 // state->dim);
@@ -62,9 +63,9 @@ public:
                 reflection_state->data_c(), state->data_c(), state->dim);
 #endif
         } else {
-            std::stringstream ss;
-            ss << "not implemented";
-            throw std::invalid_argument(ss.str());
+            std::stringstream error_message_stream;
+            error_message_stream << "not implemented";
+            throw std::invalid_argument(error_message_stream.str());
         }
     };
     /**
@@ -82,8 +83,8 @@ public:
      * @param matrix �s����Z�b�g����ϐ��̎Q��
      */
     virtual void set_matrix(ComplexMatrix&) const override {
-        std::stringstream ss;
-        ss << "ReflectionGate::set_matrix is not implemented";
-        throw std::invalid_argument(ss.str());
+        std::stringstream error_message_stream;
+        error_message_stream << "ReflectionGate::set_matrix is not implemented";
+        throw std::invalid_argument(error_message_stream.str());
     }
 };

--- a/src/cppsim/gate_reflect.hpp
+++ b/src/cppsim/gate_reflect.hpp
@@ -41,15 +41,15 @@ public:
 #ifdef _USE_GPU
             if (state->get_device_name() !=
                 reflection_state->get_device_name()) {
-                std::cerr
-                    << "Quantum state on CPU (GPU) cannot be reflected using "
-                       "quantum state on GPU (CPU)"
-                    << std::endl;
-                return;
+                std::stringstream ss;
+                ss << "Quantum state on CPU (GPU) cannot be reflected using "
+                      "quantum state on GPU (CPU)";
+                throw std::invalid_argument(ss.str());
             }
             if (state->get_device_name() == "gpu") {
-                std::cerr << "Not Implemented" << std::endl;
-                exit(0);
+                std::stringstream ss;
+                ss << "Not Implemented";
+                throw std::invalid_argument(ss.str());
                 // reversible_boolean_gate_gpu(target_index.data(),
                 // target_index.size(), function_ptr, state->data_c(),
                 // state->dim);
@@ -62,7 +62,9 @@ public:
                 reflection_state->data_c(), state->data_c(), state->dim);
 #endif
         } else {
-            std::cerr << "not implemented" << std::endl;
+            std::stringstream ss;
+            ss << "not implemented";
+            throw std::invalid_argument(ss.str());
         }
     };
     /**
@@ -80,8 +82,8 @@ public:
      * @param matrix �s����Z�b�g����ϐ��̎Q��
      */
     virtual void set_matrix(ComplexMatrix&) const override {
-        std::cerr << "ReflectionGate::set_matrix is not implemented"
-                  << std::endl;
-        exit(0);
+        std::stringstream ss;
+        ss << "ReflectionGate::set_matrix is not implemented";
+        throw std::invalid_argument(ss.str());
     }
 };

--- a/src/cppsim/gate_reversible.hpp
+++ b/src/cppsim/gate_reversible.hpp
@@ -42,8 +42,9 @@ public:
         if (state->is_state_vector()) {
 #ifdef _USE_GPU
             if (state->get_device_name() == "gpu") {
-                std::cerr << "Not Implemented" << std::endl;
-                exit(0);
+                std::stringstream ss;
+                ss << "Not Implemented";
+                throw std::invalid_argument(ss.str());
                 // reversible_boolean_gate_gpu(target_index.data(),
                 // target_index.size(), function_ptr, state->data_c(),
                 // state->dim);
@@ -58,7 +59,9 @@ public:
                 state->dim);
 #endif
         } else {
-            std::cerr << "not implemented" << std::endl;
+            std::stringstream ss;
+            ss << "not implemented";
+            throw std::invalid_argument(ss.str());
         }
     };
     /**

--- a/src/cppsim/gate_reversible.hpp
+++ b/src/cppsim/gate_reversible.hpp
@@ -42,9 +42,9 @@ public:
         if (state->is_state_vector()) {
 #ifdef _USE_GPU
             if (state->get_device_name() == "gpu") {
-                std::stringstream ss;
-                ss << "Not Implemented";
-                throw std::invalid_argument(ss.str());
+                std::stringstream error_message_stream;
+                error_message_stream << "Not Implemented";
+                throw std::invalid_argument(error_message_stream.str());
                 // reversible_boolean_gate_gpu(target_index.data(),
                 // target_index.size(), function_ptr, state->data_c(),
                 // state->dim);
@@ -59,9 +59,9 @@ public:
                 state->dim);
 #endif
         } else {
-            std::stringstream ss;
-            ss << "not implemented";
-            throw std::invalid_argument(ss.str());
+            std::stringstream error_message_stream;
+            error_message_stream << "not implemented";
+            throw std::invalid_argument(error_message_stream.str());
         }
     };
     /**

--- a/src/cppsim/general_quantum_operator.cpp
+++ b/src/cppsim/general_quantum_operator.cpp
@@ -24,11 +24,12 @@ GeneralQuantumOperator::~GeneralQuantumOperator() {
 void GeneralQuantumOperator::add_operator(const PauliOperator* mpt) {
     PauliOperator* _mpt = mpt->copy();
     if (!check_Pauli_operator(this, _mpt)) {
-        std::stringstream ss;
-        ss << "Error: GeneralQuantumOperator::add_operator(const "
-              "PauliOperator*): pauli_operator applies target qubit of "
-              "which the index is larger than qubit_count";
-        throw std::invalid_argument(ss.str());
+        std::stringstream error_message_stream;
+        error_message_stream
+            << "Error: GeneralQuantumOperator::add_operator(const "
+               "PauliOperator*): pauli_operator applies target qubit of "
+               "which the index is larger than qubit_count";
+        throw std::invalid_argument(error_message_stream.str());
     }
     if (this->_is_hermitian && std::abs(_mpt->get_coef().imag()) > 0) {
         this->_is_hermitian = false;
@@ -40,12 +41,13 @@ void GeneralQuantumOperator::add_operator(
     CPPCTYPE coef, std::string pauli_string) {
     PauliOperator* _mpt = new PauliOperator(pauli_string, coef);
     if (!check_Pauli_operator(this, _mpt)) {
-        std::stringstream ss;
-        ss << "Error: "
-              "GeneralQuantumOperator::add_operator(double,std::string):"
-              " pauli_operator applies target qubit of which the index "
-              "is larger than qubit_count";
-        throw std::invalid_argument(ss.str());
+        std::stringstream error_message_stream;
+        error_message_stream
+            << "Error: "
+               "GeneralQuantumOperator::add_operator(double,std::string):"
+               " pauli_operator applies target qubit of which the index "
+               "is larger than qubit_count";
+        throw std::invalid_argument(error_message_stream.str());
     }
     if (this->_is_hermitian && std::abs(coef.imag()) > 0) {
         this->_is_hermitian = false;
@@ -57,10 +59,11 @@ void GeneralQuantumOperator::add_operator(
 CPPCTYPE GeneralQuantumOperator::get_expectation_value(
     const QuantumStateBase* state) const {
     if (this->_qubit_count > state->qubit_count) {
-        std::stringstream ss;
-        ss << "Error: GeneralQuantumOperator::get_expectation_value(const "
-              "QuantumStateBase*): invalid qubit count";
-        throw std::invalid_argument(ss.str());
+        std::stringstream error_message_stream;
+        error_message_stream
+            << "Error: GeneralQuantumOperator::get_expectation_value(const "
+               "QuantumStateBase*): invalid qubit count";
+        throw std::invalid_argument(error_message_stream.str());
     }
     auto sum = std::accumulate(this->_operator_list.cbegin(),
         this->_operator_list.cend(), (CPPCTYPE)0.0,
@@ -75,11 +78,12 @@ CPPCTYPE GeneralQuantumOperator::get_transition_amplitude(
     const QuantumStateBase* state_ket) const {
     if (this->_qubit_count > state_bra->qubit_count ||
         state_bra->qubit_count != state_ket->qubit_count) {
-        std::stringstream ss;
-        ss << "Error: GeneralQuantumOperator::get_transition_amplitude(const "
-              "QuantumStateBase*, const QuantumStateBase*): invalid qubit "
-              "count";
-        throw std::invalid_argument(ss.str());
+        std::stringstream error_message_stream;
+        error_message_stream
+            << "Error: GeneralQuantumOperator::get_transition_amplitude(const "
+               "QuantumStateBase*, const QuantumStateBase*): invalid qubit "
+               "count";
+        throw std::invalid_argument(error_message_stream.str());
     }
 
     auto sum = std::accumulate(this->_operator_list.cbegin(),
@@ -114,13 +118,14 @@ CPPCTYPE
 GeneralQuantumOperator::solve_ground_state_eigenvalue_by_arnoldi_method(
     QuantumStateBase* state, const UINT iter_count, const CPPCTYPE mu) const {
     if (this->get_term_count() == 0) {
-        std::stringstream ss;
-        ss << "Error: "
-              "GeneralQuantumOperator::solve_ground_state_eigenvalue_by_"
-              "arnoldi_method("
-              "QuantumStateBase * state, const UINT iter_count, const "
-              "CPPCTYPE mu): At least one PauliOperator is required.";
-        throw std::invalid_argument(ss.str());
+        std::stringstream error_message_stream;
+        error_message_stream
+            << "Error: "
+               "GeneralQuantumOperator::solve_ground_state_eigenvalue_by_"
+               "arnoldi_method("
+               "QuantumStateBase * state, const UINT iter_count, const "
+               "CPPCTYPE mu): At least one PauliOperator is required.";
+        throw std::invalid_argument(error_message_stream.str());
     }
 
     // Implemented based on
@@ -203,13 +208,14 @@ GeneralQuantumOperator::solve_ground_state_eigenvalue_by_arnoldi_method(
 CPPCTYPE GeneralQuantumOperator::solve_ground_state_eigenvalue_by_power_method(
     QuantumStateBase* state, const UINT iter_count, const CPPCTYPE mu) const {
     if (this->get_term_count() == 0) {
-        std::stringstream ss;
-        ss << "Error: "
-              "GeneralQuantumOperator::solve_ground_state_eigenvalue_by_"
-              "power_method("
-              "QuantumStateBase * state, const UINT iter_count, const "
-              "CPPCTYPE mu): At least one PauliOperator is required.";
-        throw std::invalid_argument(ss.str());
+        std::stringstream error_message_stream;
+        error_message_stream
+            << "Error: "
+               "GeneralQuantumOperator::solve_ground_state_eigenvalue_by_"
+               "power_method("
+               "QuantumStateBase * state, const UINT iter_count, const "
+               "CPPCTYPE mu): At least one PauliOperator is required.";
+        throw std::invalid_argument(error_message_stream.str());
     }
 
     CPPCTYPE mu_;
@@ -572,9 +578,9 @@ GeneralQuantumOperator* create_general_quantum_operator_from_openfermion_file(
         }
     }
     if (!ifs.eof()) {
-        std::stringstream ss;
-        ss << "ERROR: Invalid format";
-        throw std::runtime_error(ss.str());
+        std::stringstream error_message_stream;
+        error_message_stream << "ERROR: Invalid format";
+        throw std::runtime_error(error_message_stream.str());
     }
     ifs.close();
 
@@ -638,9 +644,9 @@ create_split_general_quantum_operator(std::string file_path) {
     ifs.open(file_path);
 
     if (!ifs) {
-        std::stringstream ss;
-        ss << "ERROR: Cannot open file";
-        throw std::runtime_error(ss.str());
+        std::stringstream error_message_stream;
+        error_message_stream << "ERROR: Cannot open file";
+        throw std::runtime_error(error_message_stream.str());
     }
 
     // loading lines and check qubit_count
@@ -668,9 +674,9 @@ create_split_general_quantum_operator(std::string file_path) {
         }
     }
     if (!ifs.eof()) {
-        std::stringstream ss;
-        ss << "ERROR: Invalid format";
-        throw std::runtime_error(ss.str());
+        std::stringstream error_message_stream;
+        error_message_stream << "ERROR: Invalid format";
+        throw std::runtime_error(error_message_stream.str());
     }
     ifs.close();
 

--- a/src/cppsim/general_quantum_operator.cpp
+++ b/src/cppsim/general_quantum_operator.cpp
@@ -24,11 +24,11 @@ GeneralQuantumOperator::~GeneralQuantumOperator() {
 void GeneralQuantumOperator::add_operator(const PauliOperator* mpt) {
     PauliOperator* _mpt = mpt->copy();
     if (!check_Pauli_operator(this, _mpt)) {
-        std::cerr << "Error: GeneralQuantumOperator::add_operator(const "
-                     "PauliOperator*): pauli_operator applies target qubit of "
-                     "which the index is larger than qubit_count"
-                  << std::endl;
-        return;
+        std::stringstream ss;
+        ss << "Error: GeneralQuantumOperator::add_operator(const "
+              "PauliOperator*): pauli_operator applies target qubit of "
+              "which the index is larger than qubit_count";
+        throw std::invalid_argument(ss.str());
     }
     if (this->_is_hermitian && std::abs(_mpt->get_coef().imag()) > 0) {
         this->_is_hermitian = false;
@@ -40,12 +40,12 @@ void GeneralQuantumOperator::add_operator(
     CPPCTYPE coef, std::string pauli_string) {
     PauliOperator* _mpt = new PauliOperator(pauli_string, coef);
     if (!check_Pauli_operator(this, _mpt)) {
-        std::cerr << "Error: "
-                     "GeneralQuantumOperator::add_operator(double,std::string):"
-                     " pauli_operator applies target qubit of which the index "
-                     "is larger than qubit_count"
-                  << std::endl;
-        return;
+        std::stringstream ss;
+        ss << "Error: "
+              "GeneralQuantumOperator::add_operator(double,std::string):"
+              " pauli_operator applies target qubit of which the index "
+              "is larger than qubit_count";
+        throw std::invalid_argument(ss.str());
     }
     if (this->_is_hermitian && std::abs(coef.imag()) > 0) {
         this->_is_hermitian = false;
@@ -57,11 +57,10 @@ void GeneralQuantumOperator::add_operator(
 CPPCTYPE GeneralQuantumOperator::get_expectation_value(
     const QuantumStateBase* state) const {
     if (this->_qubit_count > state->qubit_count) {
-        std::cerr
-            << "Error: GeneralQuantumOperator::get_expectation_value(const "
-               "QuantumStateBase*): invalid qubit count"
-            << std::endl;
-        return 0.;
+        std::stringstream ss;
+        ss << "Error: GeneralQuantumOperator::get_expectation_value(const "
+              "QuantumStateBase*): invalid qubit count";
+        throw std::invalid_argument(ss.str());
     }
     auto sum = std::accumulate(this->_operator_list.cbegin(),
         this->_operator_list.cend(), (CPPCTYPE)0.0,
@@ -76,12 +75,11 @@ CPPCTYPE GeneralQuantumOperator::get_transition_amplitude(
     const QuantumStateBase* state_ket) const {
     if (this->_qubit_count > state_bra->qubit_count ||
         state_bra->qubit_count != state_ket->qubit_count) {
-        std::cerr
-            << "Error: GeneralQuantumOperator::get_transition_amplitude(const "
-               "QuantumStateBase*, const QuantumStateBase*): invalid qubit "
-               "count"
-            << std::endl;
-        return 0.;
+        std::stringstream ss;
+        ss << "Error: GeneralQuantumOperator::get_transition_amplitude(const "
+              "QuantumStateBase*, const QuantumStateBase*): invalid qubit "
+              "count";
+        throw std::invalid_argument(ss.str());
     }
 
     auto sum = std::accumulate(this->_operator_list.cbegin(),
@@ -116,12 +114,13 @@ CPPCTYPE
 GeneralQuantumOperator::solve_ground_state_eigenvalue_by_arnoldi_method(
     QuantumStateBase* state, const UINT iter_count, const CPPCTYPE mu) const {
     if (this->get_term_count() == 0) {
-        std::cerr << "Error: "
-                     "GeneralQuantumOperator::solve_ground_state_eigenvalue_by_"
-                     "arnoldi_method("
-                     "QuantumStateBase * state, const UINT iter_count, const "
-                     "CPPCTYPE mu): At least one PauliOperator is required.";
-        return 0;
+        std::stringstream ss;
+        ss << "Error: "
+              "GeneralQuantumOperator::solve_ground_state_eigenvalue_by_"
+              "arnoldi_method("
+              "QuantumStateBase * state, const UINT iter_count, const "
+              "CPPCTYPE mu): At least one PauliOperator is required.";
+        throw std::invalid_argument(ss.str());
     }
 
     // Implemented based on
@@ -204,12 +203,13 @@ GeneralQuantumOperator::solve_ground_state_eigenvalue_by_arnoldi_method(
 CPPCTYPE GeneralQuantumOperator::solve_ground_state_eigenvalue_by_power_method(
     QuantumStateBase* state, const UINT iter_count, const CPPCTYPE mu) const {
     if (this->get_term_count() == 0) {
-        std::cerr << "Error: "
-                     "GeneralQuantumOperator::solve_ground_state_eigenvalue_by_"
-                     "power_method("
-                     "QuantumStateBase * state, const UINT iter_count, const "
-                     "CPPCTYPE mu): At least one PauliOperator is required.";
-        return 0;
+        std::stringstream ss;
+        ss << "Error: "
+              "GeneralQuantumOperator::solve_ground_state_eigenvalue_by_"
+              "power_method("
+              "QuantumStateBase * state, const UINT iter_count, const "
+              "CPPCTYPE mu): At least one PauliOperator is required.";
+        throw std::invalid_argument(ss.str());
     }
 
     CPPCTYPE mu_;
@@ -572,8 +572,9 @@ GeneralQuantumOperator* create_general_quantum_operator_from_openfermion_file(
         }
     }
     if (!ifs.eof()) {
-        std::cerr << "ERROR: Invalid format" << std::endl;
-        return (GeneralQuantumOperator*)NULL;
+        std::stringstream ss;
+        ss << "ERROR: Invalid format";
+        throw std::runtime_error(ss.str());
     }
     ifs.close();
 
@@ -637,9 +638,9 @@ create_split_general_quantum_operator(std::string file_path) {
     ifs.open(file_path);
 
     if (!ifs) {
-        std::cerr << "ERROR: Cannot open file" << std::endl;
-        return std::make_pair(
-            (GeneralQuantumOperator*)NULL, (GeneralQuantumOperator*)NULL);
+        std::stringstream ss;
+        ss << "ERROR: Cannot open file";
+        throw std::runtime_error(ss.str());
     }
 
     // loading lines and check qubit_count
@@ -667,9 +668,9 @@ create_split_general_quantum_operator(std::string file_path) {
         }
     }
     if (!ifs.eof()) {
-        std::cerr << "ERROR: Invalid format" << std::endl;
-        return std::make_pair(
-            (GeneralQuantumOperator*)NULL, (GeneralQuantumOperator*)NULL);
+        std::stringstream ss;
+        ss << "ERROR: Invalid format";
+        throw std::runtime_error(ss.str());
     }
     ifs.close();
 

--- a/src/cppsim/general_quantum_operator.hpp
+++ b/src/cppsim/general_quantum_operator.hpp
@@ -91,9 +91,10 @@ public:
      */
     virtual const PauliOperator* get_term(UINT index) const {
         if (index >= _operator_list.size()) {
-            std::stringstream ss;
-            ss << "Error: PauliOperator::get_term(UINT): index out of range";
-            throw std::out_of_range(ss.str());
+            std::stringstream error_message_stream;
+            error_message_stream
+                << "Error: PauliOperator::get_term(UINT): index out of range";
+            throw std::out_of_range(error_message_stream.str());
         }
         return _operator_list[index];
     }

--- a/src/cppsim/general_quantum_operator.hpp
+++ b/src/cppsim/general_quantum_operator.hpp
@@ -91,10 +91,9 @@ public:
      */
     virtual const PauliOperator* get_term(UINT index) const {
         if (index >= _operator_list.size()) {
-            std::cerr
-                << "Error: PauliOperator::get_term(UINT): index out of range"
-                << std::endl;
-            return NULL;
+            std::stringstream ss;
+            ss << "Error: PauliOperator::get_term(UINT): index out of range";
+            throw std::out_of_range(ss.str());
         }
         return _operator_list[index];
     }

--- a/src/cppsim/observable.cpp
+++ b/src/cppsim/observable.cpp
@@ -17,10 +17,10 @@
 
 void HermitianQuantumOperator::add_operator(const PauliOperator* mpt) {
     if (std::abs(mpt->get_coef().imag()) > 0) {
-        std::cerr << "Error: HermitianQuantumOperator::add_operator(const "
-                     "PauliOperator* mpt): PauliOperator must be Hermitian."
-                  << std::endl;
-        return;
+        std::stringstream ss;
+        ss << "Error: HermitianQuantumOperator::add_operator(const "
+              "PauliOperator* mpt): PauliOperator must be Hermitian.";
+        throw std::invalid_argument(ss.str());
     }
     GeneralQuantumOperator::add_operator(mpt);
 }
@@ -28,10 +28,10 @@ void HermitianQuantumOperator::add_operator(const PauliOperator* mpt) {
 void HermitianQuantumOperator::add_operator(
     CPPCTYPE coef, std::string pauli_string) {
     if (std::abs(coef.imag()) > 0) {
-        std::cerr << "Error: HermitianQuantumOperator::add_operator(const "
-                     "PauliOperator* mpt): PauliOperator must be Hermitian."
-                  << std::endl;
-        return;
+        std::stringstream ss;
+        ss << "Error: HermitianQuantumOperator::add_operator(const "
+              "PauliOperator* mpt): PauliOperator must be Hermitian.";
+        throw std::invalid_argument(ss.str());
     }
     GeneralQuantumOperator::add_operator(coef, pauli_string);
 }
@@ -46,12 +46,13 @@ HermitianQuantumOperator::solve_ground_state_eigenvalue_by_lanczos_method(
     QuantumStateBase* init_state, const UINT iter_count,
     const CPPCTYPE mu) const {
     if (this->get_term_count() == 0) {
-        std::cerr << "Error: "
-                     "HermitianQuantumOperator::solve_ground_state_eigenvalue_"
-                     "by_lanczos_method("
-                     "QuantumStateBase * state, const UINT iter_count, const "
-                     "CPPCTYPE mu): At least one PauliOperator is required.";
-        return 0;
+        std::stringstream ss;
+        ss << "Error: "
+              "HermitianQuantumOperator::solve_ground_state_eigenvalue_"
+              "by_lanczos_method("
+              "QuantumStateBase * state, const UINT iter_count, const "
+              "CPPCTYPE mu): At least one PauliOperator is required.";
+        throw std::invalid_argument(ss.str());
     }
 
     // Implemented based on
@@ -195,8 +196,9 @@ HermitianQuantumOperator* create_observable_from_openfermion_file(
     ifs.open(file_path);
 
     if (!ifs) {
-        std::cerr << "ERROR: Cannot open file" << std::endl;
-        return NULL;
+        std::stringstream ss;
+        ss << "ERROR: Cannot open file";
+        throw std::runtime_error(ss.str());
     }
 
     // loading lines and check qubit_count
@@ -222,8 +224,9 @@ HermitianQuantumOperator* create_observable_from_openfermion_file(
         }
     }
     if (!ifs.eof()) {
-        std::cerr << "ERROR: Invalid format" << std::endl;
-        return NULL;
+        std::stringstream ss;
+        ss << "ERROR: Invalid format";
+        throw std::runtime_error(ss.str());
     }
     ifs.close();
 
@@ -286,9 +289,9 @@ create_split_observable(std::string file_path) {
     ifs.open(file_path);
 
     if (!ifs) {
-        std::cerr << "ERROR: Cannot open file" << std::endl;
-        return std::make_pair(
-            (HermitianQuantumOperator*)NULL, (HermitianQuantumOperator*)NULL);
+        std::stringstream ss;
+        ss << "ERROR: Cannot open file";
+        throw std::runtime_error(ss.str());
     }
 
     // loading lines and check qubit_count
@@ -314,9 +317,9 @@ create_split_observable(std::string file_path) {
         }
     }
     if (!ifs.eof()) {
-        std::cerr << "ERROR: Invalid format" << std::endl;
-        return std::make_pair(
-            (HermitianQuantumOperator*)NULL, (HermitianQuantumOperator*)NULL);
+        std::stringstream ss;
+        ss << "ERROR: Invalid format";
+        throw std::runtime_error(ss.str());
     }
     ifs.close();
 

--- a/src/cppsim/observable.cpp
+++ b/src/cppsim/observable.cpp
@@ -17,10 +17,11 @@
 
 void HermitianQuantumOperator::add_operator(const PauliOperator* mpt) {
     if (std::abs(mpt->get_coef().imag()) > 0) {
-        std::stringstream ss;
-        ss << "Error: HermitianQuantumOperator::add_operator(const "
-              "PauliOperator* mpt): PauliOperator must be Hermitian.";
-        throw std::invalid_argument(ss.str());
+        std::stringstream error_message_stream;
+        error_message_stream
+            << "Error: HermitianQuantumOperator::add_operator(const "
+               "PauliOperator* mpt): PauliOperator must be Hermitian.";
+        throw std::invalid_argument(error_message_stream.str());
     }
     GeneralQuantumOperator::add_operator(mpt);
 }
@@ -28,10 +29,11 @@ void HermitianQuantumOperator::add_operator(const PauliOperator* mpt) {
 void HermitianQuantumOperator::add_operator(
     CPPCTYPE coef, std::string pauli_string) {
     if (std::abs(coef.imag()) > 0) {
-        std::stringstream ss;
-        ss << "Error: HermitianQuantumOperator::add_operator(const "
-              "PauliOperator* mpt): PauliOperator must be Hermitian.";
-        throw std::invalid_argument(ss.str());
+        std::stringstream error_message_stream;
+        error_message_stream
+            << "Error: HermitianQuantumOperator::add_operator(const "
+               "PauliOperator* mpt): PauliOperator must be Hermitian.";
+        throw std::invalid_argument(error_message_stream.str());
     }
     GeneralQuantumOperator::add_operator(coef, pauli_string);
 }
@@ -46,13 +48,14 @@ HermitianQuantumOperator::solve_ground_state_eigenvalue_by_lanczos_method(
     QuantumStateBase* init_state, const UINT iter_count,
     const CPPCTYPE mu) const {
     if (this->get_term_count() == 0) {
-        std::stringstream ss;
-        ss << "Error: "
-              "HermitianQuantumOperator::solve_ground_state_eigenvalue_"
-              "by_lanczos_method("
-              "QuantumStateBase * state, const UINT iter_count, const "
-              "CPPCTYPE mu): At least one PauliOperator is required.";
-        throw std::invalid_argument(ss.str());
+        std::stringstream error_message_stream;
+        error_message_stream
+            << "Error: "
+               "HermitianQuantumOperator::solve_ground_state_eigenvalue_"
+               "by_lanczos_method("
+               "QuantumStateBase * state, const UINT iter_count, const "
+               "CPPCTYPE mu): At least one PauliOperator is required.";
+        throw std::invalid_argument(error_message_stream.str());
     }
 
     // Implemented based on
@@ -196,9 +199,9 @@ HermitianQuantumOperator* create_observable_from_openfermion_file(
     ifs.open(file_path);
 
     if (!ifs) {
-        std::stringstream ss;
-        ss << "ERROR: Cannot open file";
-        throw std::runtime_error(ss.str());
+        std::stringstream error_message_stream;
+        error_message_stream << "ERROR: Cannot open file";
+        throw std::runtime_error(error_message_stream.str());
     }
 
     // loading lines and check qubit_count
@@ -224,9 +227,9 @@ HermitianQuantumOperator* create_observable_from_openfermion_file(
         }
     }
     if (!ifs.eof()) {
-        std::stringstream ss;
-        ss << "ERROR: Invalid format";
-        throw std::runtime_error(ss.str());
+        std::stringstream error_message_stream;
+        error_message_stream << "ERROR: Invalid format";
+        throw std::runtime_error(error_message_stream.str());
     }
     ifs.close();
 
@@ -289,9 +292,9 @@ create_split_observable(std::string file_path) {
     ifs.open(file_path);
 
     if (!ifs) {
-        std::stringstream ss;
-        ss << "ERROR: Cannot open file";
-        throw std::runtime_error(ss.str());
+        std::stringstream error_message_stream;
+        error_message_stream << "ERROR: Cannot open file";
+        throw std::runtime_error(error_message_stream.str());
     }
 
     // loading lines and check qubit_count
@@ -317,9 +320,9 @@ create_split_observable(std::string file_path) {
         }
     }
     if (!ifs.eof()) {
-        std::stringstream ss;
-        ss << "ERROR: Invalid format";
-        throw std::runtime_error(ss.str());
+        std::stringstream error_message_stream;
+        error_message_stream << "ERROR: Invalid format";
+        throw std::runtime_error(error_message_stream.str());
     }
     ifs.close();
 

--- a/src/cppsim/pauli_operator.cpp
+++ b/src/cppsim/pauli_operator.cpp
@@ -40,9 +40,10 @@ PauliOperator::PauliOperator(std::string strings, CPPCTYPE coef) : _coef(coef) {
         else if (pauli_str == "Z" || pauli_str == "z")
             pauli_type = 3;
         else {
-            std::stringstream ss;
-            ss << "invalid Pauli string is given : " << pauli_str;
-            throw std::invalid_argument(ss.str());
+            std::stringstream error_message_stream;
+            error_message_stream << "invalid Pauli string is given : "
+                                 << pauli_str;
+            throw std::invalid_argument(error_message_stream.str());
         }
         if (pauli_type != 0) this->add_single_Pauli(index, pauli_type);
     }
@@ -67,9 +68,9 @@ PauliOperator::PauliOperator(const std::vector<UINT>& target_qubit_list,
                    Pauli_operator_type_list[term_index] == 'Z') {
             pauli_type = 3;
         } else {
-            std::stringstream ss;
-            ss << "invalid Pauli string is given : ";
-            throw std::invalid_argument(ss.str());
+            std::stringstream error_message_stream;
+            error_message_stream << "invalid Pauli string is given : ";
+            throw std::invalid_argument(error_message_stream.str());
         }
 
         if (pauli_type != 0)
@@ -172,9 +173,10 @@ CPPCTYPE PauliOperator::get_transition_amplitude(
     const QuantumStateBase* state_bra,
     const QuantumStateBase* state_ket) const {
     if ((!state_bra->is_state_vector()) || (!state_ket->is_state_vector())) {
-        std::stringstream ss;
-        ss << "get_transition_amplitude for density matrix is not implemented";
-        throw std::invalid_argument(ss.str());
+        std::stringstream error_message_stream;
+        error_message_stream
+            << "get_transition_amplitude for density matrix is not implemented";
+        throw std::invalid_argument(error_message_stream.str());
     }
 #ifdef _USE_GPU
     if (state_ket->get_device_name() == "gpu" &&

--- a/src/cppsim/pauli_operator.cpp
+++ b/src/cppsim/pauli_operator.cpp
@@ -40,9 +40,9 @@ PauliOperator::PauliOperator(std::string strings, CPPCTYPE coef) : _coef(coef) {
         else if (pauli_str == "Z" || pauli_str == "z")
             pauli_type = 3;
         else {
-            fprintf(stderr, "invalid Pauli string is given : %s\n ",
-                pauli_str.c_str());
-            assert(false);
+            std::stringstream ss;
+            ss << "invalid Pauli string is given : " << pauli_str;
+            throw std::invalid_argument(ss.str());
         }
         if (pauli_type != 0) this->add_single_Pauli(index, pauli_type);
     }
@@ -67,8 +67,9 @@ PauliOperator::PauliOperator(const std::vector<UINT>& target_qubit_list,
                    Pauli_operator_type_list[term_index] == 'Z') {
             pauli_type = 3;
         } else {
-            fprintf(stderr, "invalid Pauli string is given\n");
-            assert(false);
+            std::stringstream ss;
+            ss << "invalid Pauli string is given : ";
+            throw std::invalid_argument(ss.str());
         }
 
         if (pauli_type != 0)
@@ -171,9 +172,9 @@ CPPCTYPE PauliOperator::get_transition_amplitude(
     const QuantumStateBase* state_bra,
     const QuantumStateBase* state_ket) const {
     if ((!state_bra->is_state_vector()) || (!state_ket->is_state_vector())) {
-        std::cerr
-            << "get_transition_amplitude for density matrix is not implemented"
-            << std::endl;
+        std::stringstream ss;
+        ss << "get_transition_amplitude for density matrix is not implemented";
+        throw std::invalid_argument(ss.str());
     }
 #ifdef _USE_GPU
     if (state_ket->get_device_name() == "gpu" &&

--- a/src/cppsim/pauli_operator.hpp
+++ b/src/cppsim/pauli_operator.hpp
@@ -41,10 +41,10 @@ public:
     SinglePauliOperator(UINT index_, UINT pauli_id_)
         : _index(index_), _pauli_id(pauli_id_) {
         if (pauli_id_ > 3) {
-            std::cerr
-                << "Error: SinglePauliOperator(UINT, UINT): index must be "
-                   "either of 0,1,2,3"
-                << std::endl;
+            std::stringstream ss;
+            ss << "Error: SinglePauliOperator(UINT, UINT): index must be "
+                  "either of 0,1,2,3";
+            throw std::invalid_argument(ss.str());
         }
     };
 

--- a/src/cppsim/pauli_operator.hpp
+++ b/src/cppsim/pauli_operator.hpp
@@ -41,10 +41,11 @@ public:
     SinglePauliOperator(UINT index_, UINT pauli_id_)
         : _index(index_), _pauli_id(pauli_id_) {
         if (pauli_id_ > 3) {
-            std::stringstream ss;
-            ss << "Error: SinglePauliOperator(UINT, UINT): index must be "
-                  "either of 0,1,2,3";
-            throw std::invalid_argument(ss.str());
+            std::stringstream error_message_stream;
+            error_message_stream
+                << "Error: SinglePauliOperator(UINT, UINT): index must be "
+                   "either of 0,1,2,3";
+            throw std::invalid_argument(error_message_stream.str());
         }
     };
 

--- a/src/cppsim/state.cpp
+++ b/src/cppsim/state.cpp
@@ -8,10 +8,11 @@
 namespace state {
 CPPCTYPE inner_product(const QuantumState* state1, const QuantumState* state2) {
     if (state1->qubit_count != state2->qubit_count) {
-        std::stringstream ss;
-        ss << "Error: inner_product(const QuantumState*, const "
-              "QuantumState*): invalid qubit count";
-        throw std::invalid_argument(ss.str());
+        std::stringstream error_message_stream;
+        error_message_stream
+            << "Error: inner_product(const QuantumState*, const "
+               "QuantumState*): invalid qubit count";
+        throw std::invalid_argument(error_message_stream.str());
     }
 
     return state_inner_product(state1->data_c(), state2->data_c(), state1->dim);
@@ -27,10 +28,10 @@ QuantumState* tensor_product(
 QuantumState* permutate_qubit(
     const QuantumState* state, std::vector<UINT> qubit_order) {
     if (state->qubit_count != (UINT)qubit_order.size()) {
-        std::stringstream ss;
-        ss << "Error: permutate_qubit(const QuantumState*, "
-              "std::vector<UINT>): invalid qubit count";
-        throw std::invalid_argument(ss.str());
+        std::stringstream error_message_stream;
+        error_message_stream << "Error: permutate_qubit(const QuantumState*, "
+                                "std::vector<UINT>): invalid qubit count";
+        throw std::invalid_argument(error_message_stream.str());
     }
     UINT qubit_count = state->qubit_count;
     QuantumState* qs = new QuantumState(qubit_count);
@@ -42,10 +43,11 @@ QuantumState* drop_qubit(const QuantumState* state, std::vector<UINT> target,
     std::vector<UINT> projection) {
     if (state->qubit_count <= target.size() ||
         target.size() != projection.size()) {
-        std::stringstream ss;
-        ss << "Error: drop_qubit(const QuantumState*, std::vector<UINT>): "
-              "invalid qubit count";
-        throw std::invalid_argument(ss.str());
+        std::stringstream error_message_stream;
+        error_message_stream
+            << "Error: drop_qubit(const QuantumState*, std::vector<UINT>): "
+               "invalid qubit count";
+        throw std::invalid_argument(error_message_stream.str());
     }
     UINT qubit_count = state->qubit_count - (UINT)target.size();
     QuantumState* qs = new QuantumState(qubit_count);

--- a/src/cppsim/state.cpp
+++ b/src/cppsim/state.cpp
@@ -1,4 +1,5 @@
 ﻿#include "state.hpp"
+
 #include <csim/stat_ops.hpp>
 #include <iostream>
 
@@ -7,10 +8,10 @@
 namespace state {
 CPPCTYPE inner_product(const QuantumState* state1, const QuantumState* state2) {
     if (state1->qubit_count != state2->qubit_count) {
-        std::cerr << "Error: inner_product(const QuantumState*, const "
-                     "QuantumState*): invalid qubit count"
-                  << std::endl;
-        return 0.;
+        std::stringstream ss;
+        ss << "Error: inner_product(const QuantumState*, const "
+              "QuantumState*): invalid qubit count";
+        throw std::invalid_argument(ss.str());
     }
 
     return state_inner_product(state1->data_c(), state2->data_c(), state1->dim);
@@ -26,10 +27,10 @@ QuantumState* tensor_product(
 QuantumState* permutate_qubit(
     const QuantumState* state, std::vector<UINT> qubit_order) {
     if (state->qubit_count != (UINT)qubit_order.size()) {
-        std::cerr << "Error: permutate_qubit(const QuantumState*, "
-                     "std::vector<UINT>): invalid qubit count"
-                  << std::endl;
-        return NULL;
+        std::stringstream ss;
+        ss << "Error: permutate_qubit(const QuantumState*, "
+              "std::vector<UINT>): invalid qubit count";
+        throw std::invalid_argument(ss.str());
     }
     UINT qubit_count = state->qubit_count;
     QuantumState* qs = new QuantumState(qubit_count);
@@ -41,11 +42,10 @@ QuantumState* drop_qubit(const QuantumState* state, std::vector<UINT> target,
     std::vector<UINT> projection) {
     if (state->qubit_count <= target.size() ||
         target.size() != projection.size()) {
-        std::cerr
-            << "Error: drop_qubit(const QuantumState*, std::vector<UINT>): "
-               "invalid qubit count"
-            << std::endl;
-        return NULL;
+        std::stringstream ss;
+        ss << "Error: drop_qubit(const QuantumState*, std::vector<UINT>): "
+              "invalid qubit count";
+        throw std::invalid_argument(ss.str());
     }
     UINT qubit_count = state->qubit_count - (UINT)target.size();
     QuantumState* qs = new QuantumState(qubit_count);

--- a/src/cppsim/state.hpp
+++ b/src/cppsim/state.hpp
@@ -333,12 +333,11 @@ public:
      */
     virtual void set_computational_basis(ITYPE comp_basis) override {
         if (comp_basis >= (ITYPE)(1ULL << this->qubit_count)) {
-            std::cerr
-                << "Error: QuantumStateCpu::set_computational_basis(ITYPE): "
-                   "index of "
-                   "computational basis must be smaller than 2^qubit_count"
-                << std::endl;
-            return;
+            std::stringstream ss;
+            ss << "Error: QuantumStateCpu::set_computational_basis(ITYPE): "
+                  "index of "
+                  "computational basis must be smaller than 2^qubit_count";
+            throw std::invalid_argument(ss.str());
         }
         set_zero_state();
         _state_vector[0] = 0.;
@@ -370,11 +369,10 @@ public:
     virtual double get_zero_probability(
         UINT target_qubit_index) const override {
         if (target_qubit_index >= this->qubit_count) {
-            std::cerr
-                << "Error: QuantumStateCpu::get_zero_probability(UINT): index "
-                   "of target qubit must be smaller than qubit_count"
-                << std::endl;
-            return 0.;
+            std::stringstream ss;
+            ss << "Error: QuantumStateCpu::get_zero_probability(UINT): index "
+                  "of target qubit must be smaller than qubit_count";
+            throw std::invalid_argument(ss.str());
         }
         return M0_prob(target_qubit_index, this->data_c(), _dim);
     }
@@ -388,12 +386,11 @@ public:
     virtual double get_marginal_probability(
         std::vector<UINT> measured_values) const override {
         if (measured_values.size() != this->qubit_count) {
-            std::cerr
-                << "Error: "
-                   "QuantumStateCpu::get_marginal_probability(vector<UINT>): "
-                   "the length of measured_values must be equal to qubit_count"
-                << std::endl;
-            return 0.;
+            std::stringstream ss;
+            ss << "Error: "
+                  "QuantumStateCpu::get_marginal_probability(vector<UINT>): "
+                  "the length of measured_values must be equal to qubit_count";
+            throw std::invalid_argument(ss.str());
         }
 
         std::vector<UINT> target_index;
@@ -464,11 +461,10 @@ public:
      */
     virtual void load(const QuantumStateBase* _state) override {
         if (_state->qubit_count != this->qubit_count) {
-            std::cerr
-                << "Error: QuantumStateCpu::load(const QuantumStateBase*): "
-                   "invalid qubit count"
-                << std::endl;
-            return;
+            std::stringstream ss;
+            ss << "Error: QuantumStateCpu::load(const QuantumStateBase*): "
+                  "invalid qubit count";
+            throw std::invalid_argument(ss.str());
         }
 
         this->_classical_register = _state->classical_register;
@@ -486,11 +482,10 @@ public:
      */
     virtual void load(const std::vector<CPPCTYPE>& _state) override {
         if (_state.size() != _dim) {
-            std::cerr
-                << "Error: QuantumStateCpu::load(vector<Complex>&): invalid "
-                   "length of state"
-                << std::endl;
-            return;
+            std::stringstream ss;
+            ss << "Error: QuantumStateCpu::load(vector<Complex>&): invalid "
+                  "length of state";
+            throw std::invalid_argument(ss.str());
         }
         memcpy(
             this->data_cpp(), _state.data(), (size_t)(sizeof(CPPCTYPE) * _dim));
@@ -548,9 +543,9 @@ public:
      */
     virtual void add_state(const QuantumStateBase* state) override {
         if (state->get_device_name() == "gpu") {
-            std::cerr << "State vector on GPU cannot be added to that on CPU"
-                      << std::endl;
-            return;
+            std::stringstream ss;
+            ss << "State vector on GPU cannot be added to that on CPU";
+            throw std::invalid_argument(ss.str());
         }
         state_add(state->data_c(), this->data_c(), this->dim);
     }

--- a/src/cppsim/state.hpp
+++ b/src/cppsim/state.hpp
@@ -333,11 +333,12 @@ public:
      */
     virtual void set_computational_basis(ITYPE comp_basis) override {
         if (comp_basis >= (ITYPE)(1ULL << this->qubit_count)) {
-            std::stringstream ss;
-            ss << "Error: QuantumStateCpu::set_computational_basis(ITYPE): "
-                  "index of "
-                  "computational basis must be smaller than 2^qubit_count";
-            throw std::invalid_argument(ss.str());
+            std::stringstream error_message_stream;
+            error_message_stream
+                << "Error: QuantumStateCpu::set_computational_basis(ITYPE): "
+                   "index of "
+                   "computational basis must be smaller than 2^qubit_count";
+            throw std::invalid_argument(error_message_stream.str());
         }
         set_zero_state();
         _state_vector[0] = 0.;
@@ -369,10 +370,11 @@ public:
     virtual double get_zero_probability(
         UINT target_qubit_index) const override {
         if (target_qubit_index >= this->qubit_count) {
-            std::stringstream ss;
-            ss << "Error: QuantumStateCpu::get_zero_probability(UINT): index "
-                  "of target qubit must be smaller than qubit_count";
-            throw std::invalid_argument(ss.str());
+            std::stringstream error_message_stream;
+            error_message_stream
+                << "Error: QuantumStateCpu::get_zero_probability(UINT): index "
+                   "of target qubit must be smaller than qubit_count";
+            throw std::invalid_argument(error_message_stream.str());
         }
         return M0_prob(target_qubit_index, this->data_c(), _dim);
     }
@@ -386,11 +388,12 @@ public:
     virtual double get_marginal_probability(
         std::vector<UINT> measured_values) const override {
         if (measured_values.size() != this->qubit_count) {
-            std::stringstream ss;
-            ss << "Error: "
-                  "QuantumStateCpu::get_marginal_probability(vector<UINT>): "
-                  "the length of measured_values must be equal to qubit_count";
-            throw std::invalid_argument(ss.str());
+            std::stringstream error_message_stream;
+            error_message_stream
+                << "Error: "
+                   "QuantumStateCpu::get_marginal_probability(vector<UINT>): "
+                   "the length of measured_values must be equal to qubit_count";
+            throw std::invalid_argument(error_message_stream.str());
         }
 
         std::vector<UINT> target_index;
@@ -461,10 +464,11 @@ public:
      */
     virtual void load(const QuantumStateBase* _state) override {
         if (_state->qubit_count != this->qubit_count) {
-            std::stringstream ss;
-            ss << "Error: QuantumStateCpu::load(const QuantumStateBase*): "
-                  "invalid qubit count";
-            throw std::invalid_argument(ss.str());
+            std::stringstream error_message_stream;
+            error_message_stream
+                << "Error: QuantumStateCpu::load(const QuantumStateBase*): "
+                   "invalid qubit count";
+            throw std::invalid_argument(error_message_stream.str());
         }
 
         this->_classical_register = _state->classical_register;
@@ -482,10 +486,11 @@ public:
      */
     virtual void load(const std::vector<CPPCTYPE>& _state) override {
         if (_state.size() != _dim) {
-            std::stringstream ss;
-            ss << "Error: QuantumStateCpu::load(vector<Complex>&): invalid "
-                  "length of state";
-            throw std::invalid_argument(ss.str());
+            std::stringstream error_message_stream;
+            error_message_stream
+                << "Error: QuantumStateCpu::load(vector<Complex>&): invalid "
+                   "length of state";
+            throw std::invalid_argument(error_message_stream.str());
         }
         memcpy(
             this->data_cpp(), _state.data(), (size_t)(sizeof(CPPCTYPE) * _dim));
@@ -543,9 +548,10 @@ public:
      */
     virtual void add_state(const QuantumStateBase* state) override {
         if (state->get_device_name() == "gpu") {
-            std::stringstream ss;
-            ss << "State vector on GPU cannot be added to that on CPU";
-            throw std::invalid_argument(ss.str());
+            std::stringstream error_message_stream;
+            error_message_stream
+                << "State vector on GPU cannot be added to that on CPU";
+            throw std::invalid_argument(error_message_stream.str());
         }
         state_add(state->data_c(), this->data_c(), this->dim);
     }

--- a/src/cppsim/state_dm.cpp
+++ b/src/cppsim/state_dm.cpp
@@ -17,10 +17,10 @@ DensityMatrixCpu* tensor_product(
 DensityMatrixCpu* permutate_qubit(
     const DensityMatrixCpu* state, std::vector<UINT> qubit_order) {
     if (state->qubit_count != (UINT)qubit_order.size()) {
-        std::stringstream ss;
-        ss << "Error: permutate_qubit(const QuantumState*, "
-              "std::vector<UINT>): invalid qubit count";
-        throw std::invalid_argument(ss.str());
+        std::stringstream error_message_stream;
+        error_message_stream << "Error: permutate_qubit(const QuantumState*, "
+                                "std::vector<UINT>): invalid qubit count";
+        throw std::invalid_argument(error_message_stream.str());
     }
     UINT qubit_count = state->qubit_count;
     DensityMatrixCpu* qs = new DensityMatrixCpu(qubit_count);
@@ -31,10 +31,10 @@ DensityMatrixCpu* permutate_qubit(
 DensityMatrixCpu* partial_trace(
     const QuantumStateCpu* state, std::vector<UINT> target) {
     if (state->qubit_count <= target.size()) {
-        std::stringstream ss;
-        ss << "Error: drop_qubit(const QuantumState*, "
-              "std::vector<UINT>): invalid qubit count";
-        throw std::invalid_argument(ss.str());
+        std::stringstream error_message_stream;
+        error_message_stream << "Error: drop_qubit(const QuantumState*, "
+                                "std::vector<UINT>): invalid qubit count";
+        throw std::invalid_argument(error_message_stream.str());
     }
     UINT qubit_count = state->qubit_count - (UINT)target.size();
     DensityMatrixCpu* qs = new DensityMatrixCpu(qubit_count);
@@ -45,10 +45,10 @@ DensityMatrixCpu* partial_trace(
 DensityMatrixCpu* partial_trace(
     const DensityMatrixCpu* state, std::vector<UINT> target) {
     if (state->qubit_count <= target.size()) {
-        std::stringstream ss;
-        ss << "Error: drop_qubit(const QuantumState*, "
-              "std::vector<UINT>): invalid qubit count";
-        throw std::invalid_argument(ss.str());
+        std::stringstream error_message_stream;
+        error_message_stream << "Error: drop_qubit(const QuantumState*, "
+                                "std::vector<UINT>): invalid qubit count";
+        throw std::invalid_argument(error_message_stream.str());
     }
     UINT qubit_count = state->qubit_count - (UINT)target.size();
     DensityMatrixCpu* qs = new DensityMatrixCpu(qubit_count);

--- a/src/cppsim/state_dm.cpp
+++ b/src/cppsim/state_dm.cpp
@@ -17,10 +17,10 @@ DensityMatrixCpu* tensor_product(
 DensityMatrixCpu* permutate_qubit(
     const DensityMatrixCpu* state, std::vector<UINT> qubit_order) {
     if (state->qubit_count != (UINT)qubit_order.size()) {
-        std::cerr << "Error: permutate_qubit(const QuantumState*, "
-                     "std::vector<UINT>): invalid qubit count"
-                  << std::endl;
-        return NULL;
+        std::stringstream ss;
+        ss << "Error: permutate_qubit(const QuantumState*, "
+              "std::vector<UINT>): invalid qubit count";
+        throw std::invalid_argument(ss.str());
     }
     UINT qubit_count = state->qubit_count;
     DensityMatrixCpu* qs = new DensityMatrixCpu(qubit_count);
@@ -31,10 +31,10 @@ DensityMatrixCpu* permutate_qubit(
 DensityMatrixCpu* partial_trace(
     const QuantumStateCpu* state, std::vector<UINT> target) {
     if (state->qubit_count <= target.size()) {
-        std::cerr << "Error: drop_qubit(const QuantumState*, "
-                     "std::vector<UINT>): invalid qubit count"
-                  << std::endl;
-        return NULL;
+        std::stringstream ss;
+        ss << "Error: drop_qubit(const QuantumState*, "
+              "std::vector<UINT>): invalid qubit count";
+        throw std::invalid_argument(ss.str());
     }
     UINT qubit_count = state->qubit_count - (UINT)target.size();
     DensityMatrixCpu* qs = new DensityMatrixCpu(qubit_count);
@@ -45,10 +45,10 @@ DensityMatrixCpu* partial_trace(
 DensityMatrixCpu* partial_trace(
     const DensityMatrixCpu* state, std::vector<UINT> target) {
     if (state->qubit_count <= target.size()) {
-        std::cerr << "Error: drop_qubit(const QuantumState*, "
-                     "std::vector<UINT>): invalid qubit count"
-                  << std::endl;
-        return NULL;
+        std::stringstream ss;
+        ss << "Error: drop_qubit(const QuantumState*, "
+              "std::vector<UINT>): invalid qubit count";
+        throw std::invalid_argument(ss.str());
     }
     UINT qubit_count = state->qubit_count - (UINT)target.size();
     DensityMatrixCpu* qs = new DensityMatrixCpu(qubit_count);

--- a/src/cppsim/state_dm.hpp
+++ b/src/cppsim/state_dm.hpp
@@ -41,11 +41,12 @@ public:
      */
     virtual void set_computational_basis(ITYPE comp_basis) override {
         if (comp_basis >= (ITYPE)(1ULL << this->qubit_count)) {
-            std::stringstream ss;
-            ss << "Error: DensityMatrixCpu::set_computational_basis(ITYPE): "
-                  "index "
-                  "of computational basis must be smaller than 2^qubit_count";
-            throw std::invalid_argument(ss.str());
+            std::stringstream error_message_stream;
+            error_message_stream
+                << "Error: DensityMatrixCpu::set_computational_basis(ITYPE): "
+                   "index "
+                   "of computational basis must be smaller than 2^qubit_count";
+            throw std::invalid_argument(error_message_stream.str());
         }
         set_zero_state();
         _density_matrix[0] = 0.;
@@ -80,10 +81,11 @@ public:
     virtual double get_zero_probability(
         UINT target_qubit_index) const override {
         if (target_qubit_index >= this->qubit_count) {
-            std::stringstream ss;
-            ss << "Error: DensityMatrixCpu::get_zero_probability(UINT): index "
-                  "of target qubit must be smaller than qubit_count";
-            throw std::invalid_argument(ss.str());
+            std::stringstream error_message_stream;
+            error_message_stream
+                << "Error: DensityMatrixCpu::get_zero_probability(UINT): index "
+                   "of target qubit must be smaller than qubit_count";
+            throw std::invalid_argument(error_message_stream.str());
         }
         return dm_M0_prob(target_qubit_index, this->data_c(), _dim);
     }
@@ -97,11 +99,12 @@ public:
     virtual double get_marginal_probability(
         std::vector<UINT> measured_values) const override {
         if (measured_values.size() != this->qubit_count) {
-            std::stringstream ss;
-            ss << "Error: "
-                  "DensityMatrixCpu::get_marginal_probability(vector<UINT>): "
-                  "the length of measured_values must be equal to qubit_count";
-            throw std::invalid_argument(ss.str());
+            std::stringstream error_message_stream;
+            error_message_stream
+                << "Error: "
+                   "DensityMatrixCpu::get_marginal_probability(vector<UINT>): "
+                   "the length of measured_values must be equal to qubit_count";
+            throw std::invalid_argument(error_message_stream.str());
         }
 
         std::vector<UINT> target_index;
@@ -172,10 +175,11 @@ public:
      */
     virtual void load(const QuantumStateBase* _state) {
         if (_state->qubit_count != this->qubit_count) {
-            std::stringstream ss;
-            ss << "Error: DensityMatrixCpu::load(const QuantumStateBase*): "
-                  "invalid qubit count";
-            throw std::invalid_argument(ss.str());
+            std::stringstream error_message_stream;
+            error_message_stream
+                << "Error: DensityMatrixCpu::load(const QuantumStateBase*): "
+                   "invalid qubit count";
+            throw std::invalid_argument(error_message_stream.str());
         }
         if (_state->is_state_vector()) {
             if (_state->get_device_name() == "gpu") {
@@ -197,10 +201,11 @@ public:
      */
     virtual void load(const std::vector<CPPCTYPE>& _state) {
         if (_state.size() != _dim && _state.size() != _dim * _dim) {
-            std::stringstream ss;
-            ss << "Error: DensityMatrixCpu::load(vector<Complex>&): invalid "
-                  "length of state";
-            throw std::invalid_argument(ss.str());
+            std::stringstream error_message_stream;
+            error_message_stream
+                << "Error: DensityMatrixCpu::load(vector<Complex>&): invalid "
+                   "length of state";
+            throw std::invalid_argument(error_message_stream.str());
         }
         if (_state.size() == _dim) {
             dm_initialize_with_pure_state(
@@ -214,10 +219,11 @@ public:
     virtual void load(const Eigen::VectorXcd& _state) {
         ITYPE arg_dim = _state.size();
         if (arg_dim != _dim && arg_dim != _dim * _dim) {
-            std::stringstream ss;
-            ss << "Error: DensityMatrixCpu::load(vector<Complex>&): invalid "
-                  "length of state";
-            throw std::invalid_argument(ss.str());
+            std::stringstream error_message_stream;
+            error_message_stream
+                << "Error: DensityMatrixCpu::load(vector<Complex>&): invalid "
+                   "length of state";
+            throw std::invalid_argument(error_message_stream.str());
         }
         if (arg_dim == _dim) {
             dm_initialize_with_pure_state(
@@ -232,10 +238,11 @@ public:
         ITYPE arg_cols = _state.cols();
         ITYPE arg_rows = _state.rows();
         if (arg_cols != _dim && arg_rows != _dim * _dim) {
-            std::stringstream ss;
-            ss << "Error: DensityMatrixCpu::load(ComplexMatrix&): invalid "
-                  "length of state";
-            throw std::invalid_argument(ss.str());
+            std::stringstream error_message_stream;
+            error_message_stream
+                << "Error: DensityMatrixCpu::load(ComplexMatrix&): invalid "
+                   "length of state";
+            throw std::invalid_argument(error_message_stream.str());
         }
         memcpy(this->data_cpp(), _state.data(),
             (size_t)(sizeof(CPPCTYPE) * _dim * _dim));
@@ -297,10 +304,11 @@ public:
      */
     virtual void add_state(const QuantumStateBase* state) override {
         if (state->is_state_vector()) {
-            std::stringstream ss;
-            ss << "add state between density matrix and state vector is not "
-                  "implemented";
-            throw std::invalid_argument(ss.str());
+            std::stringstream error_message_stream;
+            error_message_stream
+                << "add state between density matrix and state vector is not "
+                   "implemented";
+            throw std::invalid_argument(error_message_stream.str());
         }
         dm_state_add(state->data_c(), this->data_c(), this->dim);
     }
@@ -313,10 +321,11 @@ public:
 
     virtual void multiply_elementwise_function(
         const std::function<CPPCTYPE(ITYPE)>&) override {
-        std::stringstream ss;
-        ss << "multiply_elementwise_function between density matrix and "
-              "state vector is not implemented";
-        throw std::invalid_argument(ss.str());
+        std::stringstream error_message_stream;
+        error_message_stream
+            << "multiply_elementwise_function between density matrix and "
+               "state vector is not implemented";
+        throw std::invalid_argument(error_message_stream.str());
     }
 
     /**

--- a/src/cppsim/state_dm.hpp
+++ b/src/cppsim/state_dm.hpp
@@ -41,12 +41,11 @@ public:
      */
     virtual void set_computational_basis(ITYPE comp_basis) override {
         if (comp_basis >= (ITYPE)(1ULL << this->qubit_count)) {
-            std::cerr
-                << "Error: DensityMatrixCpu::set_computational_basis(ITYPE): "
-                   "index "
-                   "of computational basis must be smaller than 2^qubit_count"
-                << std::endl;
-            return;
+            std::stringstream ss;
+            ss << "Error: DensityMatrixCpu::set_computational_basis(ITYPE): "
+                  "index "
+                  "of computational basis must be smaller than 2^qubit_count";
+            throw std::invalid_argument(ss.str());
         }
         set_zero_state();
         _density_matrix[0] = 0.;
@@ -81,11 +80,10 @@ public:
     virtual double get_zero_probability(
         UINT target_qubit_index) const override {
         if (target_qubit_index >= this->qubit_count) {
-            std::cerr
-                << "Error: DensityMatrixCpu::get_zero_probability(UINT): index "
-                   "of target qubit must be smaller than qubit_count"
-                << std::endl;
-            return 0.;
+            std::stringstream ss;
+            ss << "Error: DensityMatrixCpu::get_zero_probability(UINT): index "
+                  "of target qubit must be smaller than qubit_count";
+            throw std::invalid_argument(ss.str());
         }
         return dm_M0_prob(target_qubit_index, this->data_c(), _dim);
     }
@@ -99,12 +97,11 @@ public:
     virtual double get_marginal_probability(
         std::vector<UINT> measured_values) const override {
         if (measured_values.size() != this->qubit_count) {
-            std::cerr
-                << "Error: "
-                   "DensityMatrixCpu::get_marginal_probability(vector<UINT>): "
-                   "the length of measured_values must be equal to qubit_count"
-                << std::endl;
-            return 0.;
+            std::stringstream ss;
+            ss << "Error: "
+                  "DensityMatrixCpu::get_marginal_probability(vector<UINT>): "
+                  "the length of measured_values must be equal to qubit_count";
+            throw std::invalid_argument(ss.str());
         }
 
         std::vector<UINT> target_index;
@@ -175,11 +172,10 @@ public:
      */
     virtual void load(const QuantumStateBase* _state) {
         if (_state->qubit_count != this->qubit_count) {
-            std::cerr
-                << "Error: DensityMatrixCpu::load(const QuantumStateBase*): "
-                   "invalid qubit count"
-                << std::endl;
-            return;
+            std::stringstream ss;
+            ss << "Error: DensityMatrixCpu::load(const QuantumStateBase*): "
+                  "invalid qubit count";
+            throw std::invalid_argument(ss.str());
         }
         if (_state->is_state_vector()) {
             if (_state->get_device_name() == "gpu") {
@@ -201,11 +197,10 @@ public:
      */
     virtual void load(const std::vector<CPPCTYPE>& _state) {
         if (_state.size() != _dim && _state.size() != _dim * _dim) {
-            std::cerr
-                << "Error: DensityMatrixCpu::load(vector<Complex>&): invalid "
-                   "length of state"
-                << std::endl;
-            return;
+            std::stringstream ss;
+            ss << "Error: DensityMatrixCpu::load(vector<Complex>&): invalid "
+                  "length of state";
+            throw std::invalid_argument(ss.str());
         }
         if (_state.size() == _dim) {
             dm_initialize_with_pure_state(
@@ -219,11 +214,10 @@ public:
     virtual void load(const Eigen::VectorXcd& _state) {
         ITYPE arg_dim = _state.size();
         if (arg_dim != _dim && arg_dim != _dim * _dim) {
-            std::cerr
-                << "Error: DensityMatrixCpu::load(vector<Complex>&): invalid "
-                   "length of state"
-                << std::endl;
-            return;
+            std::stringstream ss;
+            ss << "Error: DensityMatrixCpu::load(vector<Complex>&): invalid "
+                  "length of state";
+            throw std::invalid_argument(ss.str());
         }
         if (arg_dim == _dim) {
             dm_initialize_with_pure_state(
@@ -238,11 +232,10 @@ public:
         ITYPE arg_cols = _state.cols();
         ITYPE arg_rows = _state.rows();
         if (arg_cols != _dim && arg_rows != _dim * _dim) {
-            std::cerr
-                << "Error: DensityMatrixCpu::load(ComplexMatrix&): invalid "
-                   "length of state"
-                << std::endl;
-            return;
+            std::stringstream ss;
+            ss << "Error: DensityMatrixCpu::load(ComplexMatrix&): invalid "
+                  "length of state";
+            throw std::invalid_argument(ss.str());
         }
         memcpy(this->data_cpp(), _state.data(),
             (size_t)(sizeof(CPPCTYPE) * _dim * _dim));
@@ -304,11 +297,10 @@ public:
      */
     virtual void add_state(const QuantumStateBase* state) override {
         if (state->is_state_vector()) {
-            std::cerr
-                << "add state between density matrix and state vector is not "
-                   "implemented"
-                << std::endl;
-            return;
+            std::stringstream ss;
+            ss << "add state between density matrix and state vector is not "
+                  "implemented";
+            throw std::invalid_argument(ss.str());
         }
         dm_state_add(state->data_c(), this->data_c(), this->dim);
     }
@@ -321,9 +313,10 @@ public:
 
     virtual void multiply_elementwise_function(
         const std::function<CPPCTYPE(ITYPE)>&) override {
-        std::cerr << "multiply_elementwise_function between density matrix and "
-                     "state vector is not implemented"
-                  << std::endl;
+        std::stringstream ss;
+        ss << "multiply_elementwise_function between density matrix and "
+              "state vector is not implemented";
+        throw std::invalid_argument(ss.str());
     }
 
     /**

--- a/src/cppsim/state_gpu.hpp
+++ b/src/cppsim/state_gpu.hpp
@@ -213,10 +213,9 @@ public:
      * @return 複素ベクトルのポインタ
      */
     virtual CPPCTYPE* data_cpp() const override {
-        std::cerr << "Cannot reinterpret state vector on GPU to cpp complex "
-                     "vector. Use duplicate_data_cpp instead."
-                  << std::endl;
-        return NULL;
+        std::runtime_error(
+            "Cannot reinterpret state vector on GPU to cpp complex "
+            "vector. Use duplicate_data_cpp instead.");
     }
 
     /**
@@ -226,11 +225,9 @@ public:
      * @return 複素ベクトルのポインタ
      */
     virtual CTYPE* data_c() const override {
-        std::cerr
-            << "Cannot reinterpret state vector on GPU to C complex vector. "
-               "Use duplicate_data_cpp instead."
-            << std::endl;
-        return NULL;
+        std::runtime_error(
+            "Cannot reinterpret state vector on GPU to C complex vector. "
+            "Use duplicate_data_cpp instead.");
     }
 
     /**

--- a/src/vqcsim/parametric_gate_factory.cpp
+++ b/src/vqcsim/parametric_gate_factory.cpp
@@ -29,11 +29,12 @@ QuantumGate_SingleParameter* ParametricRZ(
 QuantumGate_SingleParameter* ParametricPauliRotation(std::vector<UINT> target,
     std::vector<UINT> pauli_id, double initial_angle) {
     if (!check_is_unique_index_list(target)) {
-        std::cerr << "Error: gate::ParametricPauliRotation(std::vector<UINT>, "
-                     "std::vector<UINT>, double): target qubit list contains "
-                     "duplicated values."
-                  << std::endl;
-        return NULL;
+        throw std::invalid_argument(
+            "Error: gate::ParametricPauliRotation(std::vector<UINT>, "
+            "std::vector<UINT>, double): target qubit list contains "
+            "duplicated values."
+            "\nInfo: NULL used to be returned, "
+            "but it changed to throw exception.");
     }
     auto pauli = new PauliOperator(target, pauli_id, initial_angle);
     return new ClsParametricPauliRotationGate(initial_angle, pauli);

--- a/test/cppsim/test_gate.cpp
+++ b/test/cppsim/test_gate.cpp
@@ -1328,75 +1328,108 @@ TEST(GateTest, DuplicateIndex) {
         auto gate1 = gate::CNOT(10, 13);
         EXPECT_TRUE(gate1 != NULL);
         delete gate1;
-        auto gate2 = gate::CNOT(21, 21);
-        ASSERT_EQ(NULL, gate2);
+        try {
+            auto gate2 = gate::CNOT(21, 21);
+            FAIL();
+        } catch (std::invalid_argument) {
+        }
     }
     {
         auto gate1 = gate::CZ(10, 13);
         EXPECT_TRUE(gate1 != NULL);
         delete gate1;
-        auto gate2 = gate::CZ(21, 21);
-        ASSERT_EQ(NULL, gate2);
+        try {
+            auto gate2 = gate::CZ(21, 21);
+            FAIL();
+        } catch (std::invalid_argument) {
+        }
+        {
+            auto gate1 = gate::SWAP(10, 13);
+            EXPECT_TRUE(gate1 != NULL);
+            delete gate1;
+            try {
+                auto gate2 = gate::SWAP(21, 21);
+                FAIL();
+            } catch (std::invalid_argument) {
+            }
+        }
+        {
+            auto gate1 =
+                gate::Pauli({2, 1, 0, 3, 7, 9, 4}, {0, 0, 0, 0, 0, 0, 0});
+            EXPECT_TRUE(gate1 != NULL);
+            delete gate1;
+            try {
+                auto gate2 =
+                    gate::Pauli({0, 1, 3, 1, 5, 6, 2}, {0, 0, 0, 0, 0, 0, 0});
+                FAIL();
+            } catch (std::invalid_argument) {
+            }
+        }
+        {
+            auto gate1 = gate::PauliRotation(
+                {2, 1, 0, 3, 7, 9, 4}, {0, 0, 0, 0, 0, 0, 0}, 0.0);
+            EXPECT_TRUE(gate1 != NULL);
+            delete gate1;
+            try {
+                auto gate2 = gate::PauliRotation(
+                    {0, 1, 3, 1, 5, 6, 2}, {0, 0, 0, 0, 0, 0, 0}, 0.0);
+                FAIL();
+            } catch (std::invalid_argument) {
+            }
+        }
+        {
+            auto gate1 =
+                gate::DenseMatrix({10, 13}, ComplexMatrix::Identity(4, 4));
+            EXPECT_TRUE(gate1 != NULL);
+            delete gate1;
+            try {
+                auto gate2 =
+                    gate::DenseMatrix({21, 21}, ComplexMatrix::Identity(4, 4));
+                FAIL();
+            } catch (std::invalid_argument) {
+            }
+        }
+        {
+            auto matrix = SparseComplexMatrix(4, 4);
+            matrix.setIdentity();
+            auto gate1 = gate::SparseMatrix({10, 13}, matrix);
+            EXPECT_TRUE(gate1 != NULL);
+            delete gate1;
+            try {
+                auto gate2 = gate::SparseMatrix({21, 21}, matrix);
+                FAIL();
+            } catch (std::invalid_argument) {
+            }
+        }
+        {
+            auto gate1 = gate::RandomUnitary({10, 13});
+            EXPECT_TRUE(gate1 != NULL);
+            delete gate1;
+            try {
+                auto gate2 = gate::RandomUnitary({21, 21});
+                FAIL();
+            } catch (std::invalid_argument) {
+            }
+        }
+        {
+            auto ident = [](ITYPE a, ITYPE dim) { return a; };
+            auto gate1 = gate::ReversibleBoolean({10, 13}, ident);
+            EXPECT_TRUE(gate1 != NULL);
+            delete gate1;
+            try {
+                auto gate2 = gate::ReversibleBoolean({21, 21}, ident);
+                FAIL();
+            } catch (std::invalid_argument) {
+            }
+        }
+        {
+            auto gate1 = gate::TwoQubitDepolarizingNoise(10, 13, 0.1);
+            EXPECT_TRUE(gate1 != NULL);
+            delete gate1;
+            try {
+                auto gate2 = gate::TwoQubitDepolarizingNoise(21, 21, 0.1);
+                FAIL();
+            } catch (std::invalid_argument) {
+            }
+        }
     }
-    {
-        auto gate1 = gate::SWAP(10, 13);
-        EXPECT_TRUE(gate1 != NULL);
-        delete gate1;
-        auto gate2 = gate::SWAP(21, 21);
-        ASSERT_EQ(NULL, gate2);
-    }
-    {
-        auto gate1 = gate::Pauli({2, 1, 0, 3, 7, 9, 4}, {0, 0, 0, 0, 0, 0, 0});
-        EXPECT_TRUE(gate1 != NULL);
-        delete gate1;
-        auto gate2 = gate::Pauli({0, 1, 3, 1, 5, 6, 2}, {0, 0, 0, 0, 0, 0, 0});
-        ASSERT_EQ(NULL, gate2);
-    }
-    {
-        auto gate1 = gate::PauliRotation(
-            {2, 1, 0, 3, 7, 9, 4}, {0, 0, 0, 0, 0, 0, 0}, 0.0);
-        EXPECT_TRUE(gate1 != NULL);
-        delete gate1;
-        auto gate2 = gate::PauliRotation(
-            {0, 1, 3, 1, 5, 6, 2}, {0, 0, 0, 0, 0, 0, 0}, 0.0);
-        ASSERT_EQ(NULL, gate2);
-    }
-    {
-        auto gate1 = gate::DenseMatrix({10, 13}, ComplexMatrix::Identity(4, 4));
-        EXPECT_TRUE(gate1 != NULL);
-        delete gate1;
-        auto gate2 = gate::DenseMatrix({21, 21}, ComplexMatrix::Identity(4, 4));
-        ASSERT_EQ(NULL, gate2);
-    }
-    {
-        auto matrix = SparseComplexMatrix(4, 4);
-        matrix.setIdentity();
-        auto gate1 = gate::SparseMatrix({10, 13}, matrix);
-        EXPECT_TRUE(gate1 != NULL);
-        delete gate1;
-        auto gate2 = gate::SparseMatrix({21, 21}, matrix);
-        ASSERT_EQ(NULL, gate2);
-    }
-    {
-        auto gate1 = gate::RandomUnitary({10, 13});
-        EXPECT_TRUE(gate1 != NULL);
-        delete gate1;
-        auto gate2 = gate::RandomUnitary({21, 21});
-        ASSERT_EQ(NULL, gate2);
-    }
-    {
-        auto ident = [](ITYPE a, ITYPE dim) { return a; };
-        auto gate1 = gate::ReversibleBoolean({10, 13}, ident);
-        EXPECT_TRUE(gate1 != NULL);
-        delete gate1;
-        auto gate2 = gate::ReversibleBoolean({21, 21}, ident);
-        ASSERT_EQ(NULL, gate2);
-    }
-    {
-        auto gate1 = gate::TwoQubitDepolarizingNoise(10, 13, 0.1);
-        EXPECT_TRUE(gate1 != NULL);
-        delete gate1;
-        auto gate2 = gate::TwoQubitDepolarizingNoise(21, 21, 0.1);
-        ASSERT_EQ(NULL, gate2);
-    }
-}

--- a/test/cppsim/test_gate.cpp
+++ b/test/cppsim/test_gate.cpp
@@ -1343,93 +1343,92 @@ TEST(GateTest, DuplicateIndex) {
             FAIL();
         } catch (std::invalid_argument) {
         }
-        {
-            auto gate1 = gate::SWAP(10, 13);
-            EXPECT_TRUE(gate1 != NULL);
-            delete gate1;
-            try {
-                auto gate2 = gate::SWAP(21, 21);
-                FAIL();
-            } catch (std::invalid_argument) {
-            }
-        }
-        {
-            auto gate1 =
-                gate::Pauli({2, 1, 0, 3, 7, 9, 4}, {0, 0, 0, 0, 0, 0, 0});
-            EXPECT_TRUE(gate1 != NULL);
-            delete gate1;
-            try {
-                auto gate2 =
-                    gate::Pauli({0, 1, 3, 1, 5, 6, 2}, {0, 0, 0, 0, 0, 0, 0});
-                FAIL();
-            } catch (std::invalid_argument) {
-            }
-        }
-        {
-            auto gate1 = gate::PauliRotation(
-                {2, 1, 0, 3, 7, 9, 4}, {0, 0, 0, 0, 0, 0, 0}, 0.0);
-            EXPECT_TRUE(gate1 != NULL);
-            delete gate1;
-            try {
-                auto gate2 = gate::PauliRotation(
-                    {0, 1, 3, 1, 5, 6, 2}, {0, 0, 0, 0, 0, 0, 0}, 0.0);
-                FAIL();
-            } catch (std::invalid_argument) {
-            }
-        }
-        {
-            auto gate1 =
-                gate::DenseMatrix({10, 13}, ComplexMatrix::Identity(4, 4));
-            EXPECT_TRUE(gate1 != NULL);
-            delete gate1;
-            try {
-                auto gate2 =
-                    gate::DenseMatrix({21, 21}, ComplexMatrix::Identity(4, 4));
-                FAIL();
-            } catch (std::invalid_argument) {
-            }
-        }
-        {
-            auto matrix = SparseComplexMatrix(4, 4);
-            matrix.setIdentity();
-            auto gate1 = gate::SparseMatrix({10, 13}, matrix);
-            EXPECT_TRUE(gate1 != NULL);
-            delete gate1;
-            try {
-                auto gate2 = gate::SparseMatrix({21, 21}, matrix);
-                FAIL();
-            } catch (std::invalid_argument) {
-            }
-        }
-        {
-            auto gate1 = gate::RandomUnitary({10, 13});
-            EXPECT_TRUE(gate1 != NULL);
-            delete gate1;
-            try {
-                auto gate2 = gate::RandomUnitary({21, 21});
-                FAIL();
-            } catch (std::invalid_argument) {
-            }
-        }
-        {
-            auto ident = [](ITYPE a, ITYPE dim) { return a; };
-            auto gate1 = gate::ReversibleBoolean({10, 13}, ident);
-            EXPECT_TRUE(gate1 != NULL);
-            delete gate1;
-            try {
-                auto gate2 = gate::ReversibleBoolean({21, 21}, ident);
-                FAIL();
-            } catch (std::invalid_argument) {
-            }
-        }
-        {
-            auto gate1 = gate::TwoQubitDepolarizingNoise(10, 13, 0.1);
-            EXPECT_TRUE(gate1 != NULL);
-            delete gate1;
-            try {
-                auto gate2 = gate::TwoQubitDepolarizingNoise(21, 21, 0.1);
-                FAIL();
-            } catch (std::invalid_argument) {
-            }
+    }
+    {
+        auto gate1 = gate::SWAP(10, 13);
+        EXPECT_TRUE(gate1 != NULL);
+        delete gate1;
+        try {
+            auto gate2 = gate::SWAP(21, 21);
+            FAIL();
+        } catch (std::invalid_argument) {
         }
     }
+    {
+        auto gate1 = gate::Pauli({2, 1, 0, 3, 7, 9, 4}, {0, 0, 0, 0, 0, 0, 0});
+        EXPECT_TRUE(gate1 != NULL);
+        delete gate1;
+        try {
+            auto gate2 =
+                gate::Pauli({0, 1, 3, 1, 5, 6, 2}, {0, 0, 0, 0, 0, 0, 0});
+            FAIL();
+        } catch (std::invalid_argument) {
+        }
+    }
+    {
+        auto gate1 = gate::PauliRotation(
+            {2, 1, 0, 3, 7, 9, 4}, {0, 0, 0, 0, 0, 0, 0}, 0.0);
+        EXPECT_TRUE(gate1 != NULL);
+        delete gate1;
+        try {
+            auto gate2 = gate::PauliRotation(
+                {0, 1, 3, 1, 5, 6, 2}, {0, 0, 0, 0, 0, 0, 0}, 0.0);
+            FAIL();
+        } catch (std::invalid_argument) {
+        }
+    }
+    {
+        auto gate1 = gate::DenseMatrix({10, 13}, ComplexMatrix::Identity(4, 4));
+        EXPECT_TRUE(gate1 != NULL);
+        delete gate1;
+        try {
+            auto gate2 =
+                gate::DenseMatrix({21, 21}, ComplexMatrix::Identity(4, 4));
+            FAIL();
+        } catch (std::invalid_argument) {
+        }
+    }
+    {
+        auto matrix = SparseComplexMatrix(4, 4);
+        matrix.setIdentity();
+        auto gate1 = gate::SparseMatrix({10, 13}, matrix);
+        EXPECT_TRUE(gate1 != NULL);
+        delete gate1;
+        try {
+            auto gate2 = gate::SparseMatrix({21, 21}, matrix);
+            FAIL();
+        } catch (std::invalid_argument) {
+        }
+    }
+    {
+        auto gate1 = gate::RandomUnitary({10, 13});
+        EXPECT_TRUE(gate1 != NULL);
+        delete gate1;
+        try {
+            auto gate2 = gate::RandomUnitary({21, 21});
+            FAIL();
+        } catch (std::invalid_argument) {
+        }
+    }
+    {
+        auto ident = [](ITYPE a, ITYPE dim) { return a; };
+        auto gate1 = gate::ReversibleBoolean({10, 13}, ident);
+        EXPECT_TRUE(gate1 != NULL);
+        delete gate1;
+        try {
+            auto gate2 = gate::ReversibleBoolean({21, 21}, ident);
+            FAIL();
+        } catch (std::invalid_argument) {
+        }
+    }
+    {
+        auto gate1 = gate::TwoQubitDepolarizingNoise(10, 13, 0.1);
+        EXPECT_TRUE(gate1 != NULL);
+        delete gate1;
+        try {
+            auto gate2 = gate::TwoQubitDepolarizingNoise(21, 21, 0.1);
+            FAIL();
+        } catch (std::invalid_argument) {
+        }
+    }
+}

--- a/test/cppsim/test_gate.cpp
+++ b/test/cppsim/test_gate.cpp
@@ -1391,6 +1391,19 @@ TEST(GateTest, DuplicateIndex) {
             std::invalid_argument);
     }
     {
+        UINT n = 2;
+        ITYPE dim = 1ULL << n;
+        ComplexVector test_state_eigen(dim);
+        auto gate1 = gate::DiagonalMatrix({10, 13}, test_state_eigen);
+        EXPECT_TRUE(gate1 != NULL);
+        delete gate1;
+        ASSERT_THROW(
+            {
+                auto gate2 = gate::DiagonalMatrix({21, 21}, test_state_eigen);
+            },
+            std::invalid_argument);
+    }
+    {
         auto gate1 = gate::RandomUnitary({10, 13});
         EXPECT_TRUE(gate1 != NULL);
         delete gate1;

--- a/test/cppsim/test_gate.cpp
+++ b/test/cppsim/test_gate.cpp
@@ -1328,65 +1328,55 @@ TEST(GateTest, DuplicateIndex) {
         auto gate1 = gate::CNOT(10, 13);
         EXPECT_TRUE(gate1 != NULL);
         delete gate1;
-        try {
-            auto gate2 = gate::CNOT(21, 21);
-            FAIL();
-        } catch (std::invalid_argument) {
-        }
+        ASSERT_THROW(
+            { auto gate2 = gate::CNOT(21, 21); }, std::invalid_argument);
     }
     {
         auto gate1 = gate::CZ(10, 13);
         EXPECT_TRUE(gate1 != NULL);
         delete gate1;
-        try {
-            auto gate2 = gate::CZ(21, 21);
-            FAIL();
-        } catch (std::invalid_argument) {
-        }
+        ASSERT_THROW({ auto gate2 = gate::CZ(21, 21); }, std::invalid_argument);
     }
     {
         auto gate1 = gate::SWAP(10, 13);
         EXPECT_TRUE(gate1 != NULL);
         delete gate1;
-        try {
-            auto gate2 = gate::SWAP(21, 21);
-            FAIL();
-        } catch (std::invalid_argument) {
-        }
+        ASSERT_THROW(
+            { auto gate2 = gate::SWAP(21, 21); }, std::invalid_argument);
     }
     {
         auto gate1 = gate::Pauli({2, 1, 0, 3, 7, 9, 4}, {0, 0, 0, 0, 0, 0, 0});
         EXPECT_TRUE(gate1 != NULL);
         delete gate1;
-        try {
-            auto gate2 =
-                gate::Pauli({0, 1, 3, 1, 5, 6, 2}, {0, 0, 0, 0, 0, 0, 0});
-            FAIL();
-        } catch (std::invalid_argument) {
-        }
+        ASSERT_THROW(
+            {
+                auto gate2 =
+                    gate::Pauli({0, 1, 3, 1, 5, 6, 2}, {0, 0, 0, 0, 0, 0, 0});
+            },
+            std::invalid_argument);
     }
     {
         auto gate1 = gate::PauliRotation(
             {2, 1, 0, 3, 7, 9, 4}, {0, 0, 0, 0, 0, 0, 0}, 0.0);
         EXPECT_TRUE(gate1 != NULL);
         delete gate1;
-        try {
-            auto gate2 = gate::PauliRotation(
-                {0, 1, 3, 1, 5, 6, 2}, {0, 0, 0, 0, 0, 0, 0}, 0.0);
-            FAIL();
-        } catch (std::invalid_argument) {
-        }
+        ASSERT_THROW(
+            {
+                auto gate2 = gate::PauliRotation(
+                    {0, 1, 3, 1, 5, 6, 2}, {0, 0, 0, 0, 0, 0, 0}, 0.0);
+            },
+            std::invalid_argument);
     }
     {
         auto gate1 = gate::DenseMatrix({10, 13}, ComplexMatrix::Identity(4, 4));
         EXPECT_TRUE(gate1 != NULL);
         delete gate1;
-        try {
-            auto gate2 =
-                gate::DenseMatrix({21, 21}, ComplexMatrix::Identity(4, 4));
-            FAIL();
-        } catch (std::invalid_argument) {
-        }
+        ASSERT_THROW(
+            {
+                auto gate2 =
+                    gate::DenseMatrix({21, 21}, ComplexMatrix::Identity(4, 4));
+            },
+            std::invalid_argument);
     }
     {
         auto matrix = SparseComplexMatrix(4, 4);
@@ -1394,41 +1384,39 @@ TEST(GateTest, DuplicateIndex) {
         auto gate1 = gate::SparseMatrix({10, 13}, matrix);
         EXPECT_TRUE(gate1 != NULL);
         delete gate1;
-        try {
-            auto gate2 = gate::SparseMatrix({21, 21}, matrix);
-            FAIL();
-        } catch (std::invalid_argument) {
-        }
+        ASSERT_THROW(
+            {
+                auto gate2 = gate::SparseMatrix({21, 21}, matrix);
+            },
+            std::invalid_argument);
     }
     {
         auto gate1 = gate::RandomUnitary({10, 13});
         EXPECT_TRUE(gate1 != NULL);
         delete gate1;
-        try {
-            auto gate2 = gate::RandomUnitary({21, 21});
-            FAIL();
-        } catch (std::invalid_argument) {
-        }
+        ASSERT_THROW(
+            {
+                auto gate2 = gate::RandomUnitary({21, 21});
+            },
+            std::invalid_argument);
     }
     {
         auto ident = [](ITYPE a, ITYPE dim) { return a; };
         auto gate1 = gate::ReversibleBoolean({10, 13}, ident);
         EXPECT_TRUE(gate1 != NULL);
         delete gate1;
-        try {
-            auto gate2 = gate::ReversibleBoolean({21, 21}, ident);
-            FAIL();
-        } catch (std::invalid_argument) {
-        }
+        ASSERT_THROW(
+            {
+                auto gate2 = gate::ReversibleBoolean({21, 21}, ident);
+            },
+            std::invalid_argument);
     }
     {
         auto gate1 = gate::TwoQubitDepolarizingNoise(10, 13, 0.1);
         EXPECT_TRUE(gate1 != NULL);
         delete gate1;
-        try {
-            auto gate2 = gate::TwoQubitDepolarizingNoise(21, 21, 0.1);
-            FAIL();
-        } catch (std::invalid_argument) {
-        }
+        ASSERT_THROW(
+            { auto gate2 = gate::TwoQubitDepolarizingNoise(21, 21, 0.1); },
+            std::invalid_argument);
     }
 }

--- a/test/vqcsim/test.cpp
+++ b/test/vqcsim/test.cpp
@@ -213,12 +213,18 @@ TEST(ParametricGate, DuplicateIndex) {
         {2, 1, 0, 3, 7, 9, 4}, {0, 0, 0, 0, 0, 0, 0}, 0.0);
     EXPECT_TRUE(gate2 != NULL);
     delete gate2;
-    auto gate3 = gate::ParametricPauliRotation(
-        {0, 1, 3, 1, 5, 6, 2}, {0, 0, 0, 0, 0, 0, 0}, 0.0);
-    ASSERT_EQ(NULL, gate3);
-    auto gate4 = gate::ParametricPauliRotation(
-        {0, 3, 5, 2, 5, 6, 2}, {0, 0, 0, 0, 0, 0, 0}, 0.0);
-    ASSERT_EQ(NULL, gate4);
+    ASSERT_THROW(
+        {
+            auto gate3 = gate::ParametricPauliRotation(
+                {0, 1, 3, 1, 5, 6, 2}, {0, 0, 0, 0, 0, 0, 0}, 0.0);
+        },
+        std::invalid_argument);
+    ASSERT_THROW(
+        {
+            auto gate4 = gate::ParametricPauliRotation(
+                {0, 3, 5, 2, 5, 6, 2}, {0, 0, 0, 0, 0, 0, 0}, 0.0);
+        },
+        std::invalid_argument);
 }
 
 TEST(GradCalculator, BasicCheck) {


### PR DESCRIPTION
close #201 
fprintfやcerrで標準エラー出力に出力して適当にreturnしたりexit(0)したりしていたものをすべてC++のexceptionに置き換えました。
Vimの`%s/\vstd::cerr(\_.{-})(\<\< std::endl)?;(\_s*exit\(0\);)?(\_s*return\_.{-};)?/std::stringstream ss;\rss\1;\rthrow std::invalid_argument(ss.str());/g`で機械的に置換してから目視で確認・訂正する形をとったので確認漏れで変な置換が行われていたりcerrが残っていたり、`invalid_argument`にするべきでない例外が残っているかもしれません。確認よろしくおねがいします。