### PR TITLE
GPUのCIを再稼働させる

### DIFF
--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Install boost
         run: sudo apt install libboost-dev
-
+      
       - name: Install Python dependencies
         run: pip install -U --only-binary=numpy,scipy numpy scipy openfermion
 
@@ -106,6 +106,10 @@ jobs:
 
       - name: Install boost
         run: sudo apt install libboost-dev
+
+      - name: Install CUDA toolkit
+        uses: Jimver/cuda-toolkit@v0.2.5
+        id: cuda-toolkit
 
       - name: Install qulacs for Ubuntu
         run: ./script/build_gcc_with_gpu.sh

--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -115,7 +115,7 @@ jobs:
         run: ./script/build_gcc_with_gpu.sh
 
       - name: Install qulacs Python module
-        run: python setup.py install
+        run: python setup_gpu.py install
 
       # Testing is removed because GPU is not available for GitHub-Hosted Runner.
 

--- a/script/build_gcc.sh
+++ b/script/build_gcc.sh
@@ -1,10 +1,12 @@
 #!/bin/sh
 
+set -ex
+
 GCC_COMMAND=${C_COMPILER:-"gcc"}
 GXX_COMMAND=${CXX_COMPILER:-"g++"}
 OPT_FLAGS=${QULACS_OPT_FLAGS:-"-mtune=native -march=native -mfpmath=both"}
 
-mkdir ./build
+mkdir -p ./build
 cd ./build
 cmake -G "Unix Makefiles" -D CMAKE_C_COMPILER=$GCC_COMMAND -D CMAKE_CXX_COMPILER=$GXX_COMMAND -D OPT_FLAGS="$OPT_FLAGS" -D CMAKE_BUILD_TYPE=Release-D USE_GPU:STR=No ..
 make -j $(nproc)

--- a/script/build_gcc_with_gpu.sh
+++ b/script/build_gcc_with_gpu.sh
@@ -1,10 +1,12 @@
 #!/bin/sh
 
+set -ex
+
 GCC_COMMAND=${C_COMPILER:-"gcc"}
 GXX_COMMAND=${CXX_COMPILER:-"g++"}
 OPT_FLAGS=${QULACS_OPT_FLAGS:-"-mtune=native -march=native -mfpmath=both"}
 
-mkdir ./build
+mkdir -p ./build
 cd ./build
 cmake -G "Unix Makefiles" -D CMAKE_C_COMPILER=$GCC_COMMAND -D CMAKE_CXX_COMPILER=$GXX_COMMAND -D OPT_FLAGS="$OPT_FLAGS" -D CMAKE_BUILD_TYPE=Release -D USE_GPU:STR=Yes ..
 make -j $(nproc)


### PR DESCRIPTION
close #207 

GPUのCIは、環境にcudaがインストールされていないためビルドがそもそも実行されておらず、そのまま成功マークが付いていました。
このプルリクでは、ビルドが実行されなかった場合は[失敗マークをつけるようにしました](https://github.com/Qulacs-Osaka/qulacs-osaka/pull/211/commits/5aa47f3ac7450ef95335a29ea4fda83ccf621dbf)。また、cudaのインストールステップを追加しました。