### PR TITLE
PauliOperatorの引数に与えた文字列から余計な空白文字を除去する

### DIFF
--- a/src/cppsim/pauli_operator.cpp
+++ b/src/cppsim/pauli_operator.cpp
@@ -25,7 +25,7 @@
 #include "state.hpp"
 
 PauliOperator::PauliOperator(std::string strings, CPPCTYPE coef) : _coef(coef) {
-    std::stringstream ss(strings);
+    std::stringstream ss(rtrim(strings));
     std::string pauli_str;
     UINT index, pauli_type = 0;
     while (!ss.eof()) {

--- a/src/cppsim/utility.cpp
+++ b/src/cppsim/utility.cpp
@@ -4,6 +4,8 @@
 
 #include "utility.hpp"
 
+#include <cctype>
+
 void get_Pauli_matrix(
     ComplexMatrix& matrix, const std::vector<UINT>& pauli_id_list) {
     ITYPE matrix_dim = 1ULL << pauli_id_list.size();

--- a/src/cppsim/utility.cpp
+++ b/src/cppsim/utility.cpp
@@ -135,3 +135,10 @@ bool check_is_unique_index_list(std::vector<UINT> index_list) {
     }
     return flag;
 }
+
+std::string& rtrim(std::string& str) {
+    auto it = std::find_if(str.rbegin(), str.rend(),
+        [](unsigned char c) { return !std::isspace(c); });
+    str.erase(it.base(), str.end());
+    return str;
+}

--- a/src/cppsim/utility.hpp
+++ b/src/cppsim/utility.hpp
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <cctype>
 #include <chrono>
 #include <cstdio>
 #include <random>
@@ -213,3 +214,11 @@ DllExport std::tuple<double, double, std::string> parse_openfermion_line(
  * @return 重複がある場合にtrue、ない場合にfalse
  */
 bool check_is_unique_index_list(std::vector<UINT> index_list);
+
+/**
+ * \~japanese-en 与えられた文字列の末尾の空白文字を削除します。
+ *
+ * @param[in] str 文字列
+ * @return 末尾の空白文字を削除された文字列
+ */
+std::string& rtrim(std::string& str);

--- a/src/cppsim/utility.hpp
+++ b/src/cppsim/utility.hpp
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <cctype>
 #include <chrono>
 #include <cstdio>
 #include <random>

--- a/test/cppsim/test_pauli_operator.cpp
+++ b/test/cppsim/test_pauli_operator.cpp
@@ -1,0 +1,12 @@
+#include <gtest/gtest.h>
+
+#include <cppsim/pauli_operator.hpp>
+
+TEST(PauliOperatorTest, ContainsExtraWhitespace) {
+    PauliOperator expected = PauliOperator("X 0", 1.0);
+    PauliOperator pauli_whitespace = PauliOperator("X 0 ", 1.0);
+
+    EXPECT_EQ(1, pauli_whitespace.get_index_list().size());
+    EXPECT_EQ(1, pauli_whitespace.get_pauli_id_list().size());
+    EXPECT_EQ(expected.get_pauli_string(), pauli_whitespace.get_pauli_string());
+}


### PR DESCRIPTION
Close #220 

本家qulacsにおいて https://github.com/qulacs/qulacs/commit/5a1707991ea392bfe9208beab97565d043e22719 のコミットで追加された処理をqulacs-osakaに取り込みました。
また、余計な空白文字を除去することで、期待する動作になっていることを確かめるテストを追加しました。