### PR TITLE
add $(nproc) option to vscode tasks

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -9,7 +9,7 @@
         {
             "label": "test",
             "type": "shell",
-            "command": "make test -C build -j",
+            "command": "make test -C build -j $(nproc)",
             "dependsOn": [
                 "build gcc"
             ]
@@ -17,7 +17,7 @@
         {
             "label": "pythontest",
             "type": "shell",
-            "command": "make pythontest -C build -j",
+            "command": "make pythontest -C build -j $(nproc)",
             "dependsOn": [
                 "build gcc"
             ]


### PR DESCRIPTION
close #226 

vscodeのtaskのtestとpythontestについて、-j $(nproc)オプションを指定しました。
これによってtest時に無制限に並列数が上がってリソースを使い潰すことを防ぐことができます。