### PR TITLE
Use GITHUB_REPOSITORY variable in clang-format job

### DIFF
--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -141,13 +141,13 @@ jobs:
         if: ${{ github.event_name == 'pull_request' }}
         run: |
           cd /
-          git clone -b "${GITHUB_HEAD_REF#refs/heads/}" https://github.com/Qulacs-Osaka/qulacs-osaka
-        
+          git clone -b "${GITHUB_HEAD_REF#refs/heads/}" https://github.com/${GITHUB_REPOSITORY}
+
       - name: clone /qulacs-osaka (push)
         if: ${{ github.event_name == 'push' }}
         run: |
           cd /
-          git clone -b "${GITHUB_REF#refs/heads/}" https://github.com/Qulacs-Osaka/qulacs-osaka
+          git clone -b "${GITHUB_REF#refs/heads/}" https://github.com/${GITHUB_REPOSITORY}
 
       - name: format
         run: qulacs_format

--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -140,12 +140,14 @@ jobs:
       # This job is running on a docker container.
       # We can't use actions/checkout because Node.js is not installed on the container.
       # Therefore, we use `git clone` instead of actions/checkout.
-      # We use ${GITHUB_REPOSITORY} for the repository url to support PR from the forked repository of Qulacs-Osaka/qulacs-osaka.
       - name: clone /qulacs-osaka (pull_request)
         if: ${{ github.event_name == 'pull_request' }}
+        env:
+          # We use $REPOSITORY to support PR from the forked repository of Qulacs-Osaka/qulacs-osaka.
+          REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
         run: |
           cd /
-          git clone -b "${GITHUB_HEAD_REF#refs/heads/}" https://github.com/${GITHUB_REPOSITORY}
+          git clone -b "${GITHUB_HEAD_REF#refs/heads/}" https://github.com/$REPOSITORY
 
       - name: clone /qulacs-osaka (push)
         if: ${{ github.event_name == 'push' }}

--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -137,6 +137,10 @@ jobs:
     container:
       image: ghcr.io/qulacs-osaka/qulacs-ubuntu-clang-format:latest
     steps:
+      # This job is running on a docker container.
+      # We can't use actions/checkout because Node.js is not installed on the container.
+      # Therefore, we use `git clone` instead of actions/checkout.
+      # We use ${GITHUB_REPOSITORY} for the repository url to support PR from the forked repository of Qulacs-Osaka/qulacs-osaka.
       - name: clone /qulacs-osaka (pull_request)
         if: ${{ github.event_name == 'pull_request' }}
         run: |


### PR DESCRIPTION
Close #238 

## 概要

`GITHUB_REPOSITORY`を使ってリポジトリURLを指定することで、fork先からのPRでもclang-formatを実行出来るようにします。