### PR TITLE
Restrict trigger to run Windows and wheel build CI

### DIFF
--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   gcc8-build:
     name: GCC8 build
-    if: github.event.review.state == "approved"
+    if: github.event.review.state == 'approved'
     strategy:
       matrix:
         python-version: ["3.7.5"]

--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -7,16 +7,16 @@ on:
       - ".vscode/**"
       - "doc/**"
       - "*.md"
-  pull_request:
-    paths-ignore:
-      - ".devcontainer/**"
-      - ".vscode/**"
-      - "doc/**"
-      - "*.md"
+    branches:
+      - "dev"
+  pull_request_review:
+    types: [submitted, edited]
+  workflow_dispatch:
 
 jobs:
   gcc8-build:
     name: GCC8 build
+    if: github.event.review.state == "approved"
     strategy:
       matrix:
         python-version: ["3.7.5"]

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -9,16 +9,16 @@ on:
       - "*.md"
     branches:
       - "dev"
-  pull_request:
-    paths-ignore:
-      - ".devcontainer/**"
-      - ".vscode/**"
-      - "doc/**"
-      - "*.md"
+    tags:
+      - "v*"
+  pull_request_review:
+    types: [submitted, edited]
+  workflow_dispatch:
 
 jobs:
   wheel-build:
     name: Python wheel build
+    if: github.event.review.state == "approved"
     strategy:
       matrix:
         python-version: ["3.7.5"]

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -18,7 +18,7 @@ on:
 jobs:
   wheel-build:
     name: Python wheel build
-    if: github.event.review.state == "approved"
+    if: github.event.review.state == 'approved'
     strategy:
       matrix:
         python-version: ["3.7.5"]


### PR DESCRIPTION
close #233 
実行に時間がかかっている Windows と Wheel build の CI の実行条件を変更しました．
基本的には PR の approve で実行するようにして，それ以外のタイミングで実行したいときは workflow_dispatch を使用するようにしました．
PR への特定のコメントで実行するという案もありましたが，今回は見送りました．workflow_dispatch を押しに行くのが面倒だったら改めて検討しようと思います．