### PR TITLE
Install cereal and Eigen in Dockerfile

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -63,6 +63,6 @@ RUN git clone https://github.com/USCiLab/cereal.git -b v1.3.0 --depth 1 /tmp/cer
     && rm -rf /tmp/cereal
 
 # Install Eigen
-RUN git clone https://gitlab.com/libeigen/eigen.git -b 3.4.0 --depth 1 /tmp/eigen \
+RUN git clone https://gitlab.com/libeigen/eigen.git -b 3.3.7 --depth 1 /tmp/eigen \
     && cp -r /tmp/eigen/Eigen /usr/local/include \
     && rm -rf /tmp/eigen

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -58,7 +58,7 @@ RUN git clone https://github.com/pyenv/pyenv.git ${PYENV_ROOT} \
     && chmod -R 777 /.pyenv
 
 # Install cereal
-RUN git clone https://github.com/USCiLab/cereal.git -b v1.3.0 /tmp/cereal \
+RUN git clone https://github.com/USCiLab/cereal.git -b v1.3.0 --depth 1 /tmp/cereal \
     && cp -r /tmp/cereal/include/cereal /usr/local/include \
     && rm -rf /tmp/cereal
 

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -63,6 +63,6 @@ RUN git clone https://github.com/USCiLab/cereal.git -b v1.3.0 --depth 1 /tmp/cer
     && rm -rf /tmp/cereal
 
 # Install Eigen
-RUN git clone https://gitlab.com/libeigen/eigen.git -b 3.4.0 /tmp/eigen \
+RUN git clone https://gitlab.com/libeigen/eigen.git -b 3.4.0 --depth 1 /tmp/eigen \
     && cp -r /tmp/eigen/Eigen /usr/local/include \
     && rm -rf /tmp/eigen

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -56,3 +56,11 @@ RUN git clone https://github.com/pyenv/pyenv.git ${PYENV_ROOT} \
     && python -m pip install --upgrade pip \
     && pip install black flake8 mypy numpy openfermion pybind11-stubgen scipy wheel \
     && chmod -R 777 /.pyenv
+
+# Install cereal
+Run git clone https://github.com/USCiLab/cereal.git /tmp/cereal \
+    && cp -r /tmp/cereal/include/cereal /usr/local/include
+
+# Install Eigen
+Run git clone https://gitlab.com/libeigen/eigen.git /tmp/eigen \
+    && cp -r /tmp/eigen/Eigen /usr/local/include

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -58,9 +58,11 @@ RUN git clone https://github.com/pyenv/pyenv.git ${PYENV_ROOT} \
     && chmod -R 777 /.pyenv
 
 # Install cereal
-Run git clone https://github.com/USCiLab/cereal.git /tmp/cereal \
-    && cp -r /tmp/cereal/include/cereal /usr/local/include
+RUN git clone https://github.com/USCiLab/cereal.git -b v1.3.0 /tmp/cereal \
+    && cp -r /tmp/cereal/include/cereal /usr/local/include \
+    && rm -rf /tmp/cereal
 
 # Install Eigen
-Run git clone https://gitlab.com/libeigen/eigen.git /tmp/eigen \
-    && cp -r /tmp/eigen/Eigen /usr/local/include
+RUN git clone https://gitlab.com/libeigen/eigen.git -b 3.4.0 /tmp/eigen \
+    && cp -r /tmp/eigen/Eigen /usr/local/include \
+    && rm -rf /tmp/eigen


### PR DESCRIPTION
cerealとEigenをDevcontainer構築時に`usr/local/include`にインストールすることでビルド前からincludeできるようにしました。