### PR TITLE
Allow to fail once in ObservableTest

### DIFF
--- a/test/cppsim/test_hamiltonian.cpp
+++ b/test/cppsim/test_hamiltonian.cpp
@@ -383,7 +383,7 @@ std::string test_eigenvalue(Observable& observable, const UINT iter_count,
 TEST(ObservableTest, MinimumEigenvalueByPowerMethod) {
     constexpr double eps = 1e-2;
     constexpr UINT qubit_count = 4;
-    constexpr UINT test_count = 5;
+    constexpr UINT test_count = 10;
     UINT pass_count = 0;
     Random random;
 
@@ -399,7 +399,7 @@ TEST(ObservableTest, MinimumEigenvalueByPowerMethod) {
         else
             std::cerr << err_message;
     }
-    ASSERT_GE(pass_count, 4);
+    ASSERT_GE(pass_count, test_count - 1);
 }
 
 TEST(ObservableTest, MinimumEigenvalueByArnoldiMethod) {
@@ -422,7 +422,7 @@ TEST(ObservableTest, MinimumEigenvalueByArnoldiMethod) {
         else
             std::cerr << err_message;
     }
-    ASSERT_GE(pass_count, 4);
+    ASSERT_GE(pass_count, test_count - 1);
 }
 
 void add_identity(Observable* observable, Random random) {
@@ -459,7 +459,7 @@ TEST(ObservableTest, MinimumEigenvalueByArnoldiMethodWithIdentity) {
         else
             std::cerr << err_message;
     }
-    ASSERT_GE(pass_count, 4);
+    ASSERT_GE(pass_count, test_count - 1);
 }
 
 TEST(ObservableTest, MinimumEigenvalueByLanczosMethod) {
@@ -482,7 +482,7 @@ TEST(ObservableTest, MinimumEigenvalueByLanczosMethod) {
         else
             std::cerr << err_message;
     }
-    ASSERT_GE(pass_count, 4);
+    ASSERT_GE(pass_count, test_count - 1);
 }
 
 TEST(ObservableTest, GetDaggerTest) {

--- a/test/util/util.hpp
+++ b/test/util/util.hpp
@@ -194,7 +194,8 @@ static std::string _check_near(double val1, double val2, double eps,
     double diff = std::abs(val1 - val2);
     if (diff <= eps) return "";
     std::stringstream error_message_stream;
-    error_message_stream << "The difference between " << val1_name << " and "
+    error_message_stream << file << ":" << line << " Failure\n"
+                         << "The difference between " << val1_name << " and "
                          << val2_name << " is " << diff << ", which exceeds "
                          << eps_name << ", where\n"
                          << val1_name << " evaluates to " << val1 << ",\n"

--- a/test/util/util.hpp
+++ b/test/util/util.hpp
@@ -195,10 +195,10 @@ static std::string _check_near(double val1, double val2, double eps,
     if (diff <= eps) return "";
     std::stringstream error_message_stream;
     error_message_stream << "The difference between " << val1_name << " and "
-                         << val2_name << " is " << diff << ", whch exceeds "
+                         << val2_name << " is " << diff << ", which exceeds "
                          << eps_name << ", where\n"
                          << val1_name << " evaluates to " << val1 << ",\n"
                          << val2_name << " evaluates to " << val2 << ", and\n"
-                         << eps_name << "evaluates to " << eps << ".\n";
+                         << eps_name << " evaluates to " << eps << ".\n";
     return error_message_stream.str();
 }

--- a/test/util/util.hpp
+++ b/test/util/util.hpp
@@ -186,10 +186,9 @@ static void state_equal(const CTYPE* state, const Eigen::VectorXcd& test_state,
     }
 }
 
-#ifndef _CHECK_NEAR
 #define _CHECK_NEAR(val1, val2, eps) \
     _check_near(val1, val2, eps, #val1, #val2, #eps, __FILE__, __LINE__)
-std::string _check_near(double val1, double val2, double eps,
+static std::string _check_near(double val1, double val2, double eps,
     std::string val1_name, std::string val2_name, std::string eps_name,
     std::string file, UINT line) {
     double diff = std::abs(val1 - val2);
@@ -203,4 +202,3 @@ std::string _check_near(double val1, double val2, double eps,
                          << eps_name << "evaluates to " << eps << ".\n";
     return error_message_stream.str();
 }
-#endif

--- a/test/util/util.hpp
+++ b/test/util/util.hpp
@@ -185,3 +185,22 @@ static void state_equal(const CTYPE* state, const Eigen::VectorXcd& test_state,
             << std::endl;
     }
 }
+
+#ifndef _CHECK_NEAR
+#define _CHECK_NEAR(val1, val2, eps) \
+    _check_near(val1, val2, eps, #val1, #val2, #eps, __FILE__, __LINE__)
+std::string _check_near(double val1, double val2, double eps,
+    std::string val1_name, std::string val2_name, std::string eps_name,
+    std::string file, UINT line) {
+    double diff = std::abs(val1 - val2);
+    if (diff <= eps) return "";
+    std::stringstream error_message_stream;
+    error_message_stream << "The difference between " << val1_name << " and "
+                         << val2_name << " is " << diff << ", whch exceeds "
+                         << eps_name << ", where\n"
+                         << val1_name << " evaluates to " << val1 << ",\n"
+                         << val2_name << " evaluates to " << val2 << ", and\n"
+                         << eps_name << "evaluates to " << eps << ".\n";
+    return error_message_stream.str();
+}
+#endif


### PR DESCRIPTION
close #280 

ObservableTest(特に`MinimumEigenvalueByPowerMethod`)は乱数次第でテストに落ちがちでした。
テスト内容は「5回や10回連続でテストを通す」というものでしたが、どうしてもたまに落ちるものは落ちるため、「10回テストを行い、9回以上一定以下の誤差を出せればOK」という形式に変更しました。