### PR TITLE
remove both ref/heads/ and refs/tags/ on branch or tag name to clone

### DIFF
--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -149,13 +149,13 @@ jobs:
           REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
         run: |
           cd /
-          git clone -b "${GITHUB_HEAD_REF#refs/heads/}" https://github.com/$REPOSITORY
+          git clone -b "${${GITHUB_HEAD_REF#refs/heads/}#refs/tags/}" https://github.com/$REPOSITORY
 
       - name: clone /qulacs-osaka (push)
         if: ${{ github.event_name == 'push' }}
         run: |
           cd /
-          git clone -b "${GITHUB_REF#refs/heads/}" https://github.com/${GITHUB_REPOSITORY}
+          git clone -b "${${GITHUB_REF#refs/heads/}#refs/tags/}" https://github.com/${GITHUB_REPOSITORY}
 
       - name: format
         run: qulacs_format

--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -149,13 +149,13 @@ jobs:
           REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
         run: |
           cd /
-          git clone -b "${${GITHUB_HEAD_REF#refs/heads/}#refs/tags/}" https://github.com/$REPOSITORY
+          git clone -b "${GITHUB_HEAD_REF#refs/*/}" https://github.com/$REPOSITORY
 
       - name: clone /qulacs-osaka (push)
         if: ${{ github.event_name == 'push' }}
         run: |
           cd /
-          git clone -b "${${GITHUB_REF#refs/heads/}#refs/tags/}" https://github.com/${GITHUB_REPOSITORY}
+          git clone -b "${GITHUB_REF#refs/*/}" https://github.com/${GITHUB_REPOSITORY}
 
       - name: format
         run: qulacs_format


### PR DESCRIPTION
close #288 
ブランチのPRだと`GITHUB_REF`に`refs/heads/`が付きますが、タグのpushの場合は`refs/tags`がつくためそれも外す必要があります。