### PR TITLE
remove duplicated comment in stubs for overloaded function

### DIFF
--- a/pysrc/qulacs/__init__.pyi
+++ b/pysrc/qulacs/__init__.pyi
@@ -94,8 +94,6 @@ class GeneralQuantumOperator():
     def add_operator(self, coef: complex, pauli_string: str) -> None: 
         """
         Add Pauli operator
-
-        Add Pauli operator
         """
     @typing.overload
     def add_operator(self, pauli_operator: PauliOperator) -> None: ...
@@ -147,8 +145,6 @@ class GradCalculator():
     def calculate_grad(*args, **kwargs) -> typing.Any: 
         """
         Calculate Grad
-
-        Calculate Grad
         """
     @typing.overload
     def calculate_grad(self, parametric_circuit: ParametricQuantumCircuit, observable: Observable) -> typing.List[complex]: ...
@@ -176,16 +172,12 @@ class Observable(GeneralQuantumOperator):
     def add_operator(self, coef: complex, string: str) -> None: 
         """
         Add Pauli operator
-
-        Add Pauli operator
         """
     @typing.overload
     def add_operator(self, pauli_operator: PauliOperator) -> None: ...
     @typing.overload
     def add_random_operator(self, operator_count: int) -> None: 
         """
-        Add random pauli operator
-
         Add random pauli operator
         """
     @typing.overload
@@ -324,8 +316,6 @@ class QuantumCircuit():
     def add_dense_matrix_gate(self, index: int, matrix: numpy.ndarray[numpy.complex128, _Shape[m, n]]) -> None: 
         """
         Add dense matrix gate
-
-        Add dense matrix gate
         """
     @typing.overload
     def add_dense_matrix_gate(self, index_list: typing.List[int], matrix: numpy.ndarray[numpy.complex128, _Shape[m, n]]) -> None: ...
@@ -337,16 +327,12 @@ class QuantumCircuit():
     def add_gate(self, gate: QuantumGateBase) -> None: 
         """
         Add gate with copy
-
-        Add gate with copy
         """
     @typing.overload
     def add_gate(self, gate: QuantumGateBase, position: int) -> None: ...
     @typing.overload
     def add_multi_Pauli_gate(self, index_list: typing.List[int], pauli_ids: typing.List[int]) -> None: 
         """
-        Add multi-qubit Pauli gate
-
         Add multi-qubit Pauli gate
         """
     @typing.overload
@@ -355,8 +341,6 @@ class QuantumCircuit():
     def add_multi_Pauli_rotation_gate(self, index_list: typing.List[int], pauli_ids: typing.List[int], angle: float) -> None: 
         """
         Add multi-qubit Pauli rotation gate
-
-        Add multi-qubit Pauli gate
         """
     @typing.overload
     def add_multi_Pauli_rotation_gate(self, pauli: PauliOperator) -> None: ...
@@ -371,8 +355,6 @@ class QuantumCircuit():
     @typing.overload
     def add_random_unitary_gate(self, index_list: typing.List[int]) -> None: 
         """
-        Add random unitary gate
-
         Add random unitary gate
         """
     @typing.overload
@@ -425,8 +407,6 @@ class QuantumCircuit():
     @typing.overload
     def update_quantum_state(self, state: QuantumStateBase) -> None: 
         """
-        Update quantum state
-
         Update quantum state
         """
     @typing.overload
@@ -518,8 +498,6 @@ class ParametricQuantumCircuit(QuantumCircuit):
     def add_gate(self, gate: QuantumGateBase) -> None: 
         """
         Add gate
-
-        Add gate
         """
     @typing.overload
     def add_gate(self, gate: QuantumGateBase, position: int) -> None: ...
@@ -538,8 +516,6 @@ class ParametricQuantumCircuit(QuantumCircuit):
     @typing.overload
     def add_parametric_gate(self, gate: QuantumGate_SingleParameter) -> None: 
         """
-        Add parametric gate
-
         Add parametric gate
         """
     @typing.overload
@@ -605,8 +581,6 @@ class QuantumCircuitSimulator():
     @typing.overload
     def initialize_random_state(self) -> None: 
         """
-        Initialize state with random pure state
-
         Initialize state with random pure state
         """
     @typing.overload
@@ -782,8 +756,6 @@ class QuantumState(QuantumStateBase):
     def load(self, state: QuantumStateBase) -> None: 
         """
         Load quantum state vector
-
-        Load quantum state vector
         """
     @typing.overload
     def load(self, state: typing.List[complex]) -> None: ...
@@ -803,16 +775,12 @@ class QuantumState(QuantumStateBase):
     def sampling(self, count: int) -> typing.List[int]: 
         """
         Sampling measurement results
-
-        Sampling measurement results
         """
     @typing.overload
     def sampling(self, count: int, seed: int) -> typing.List[int]: ...
     @typing.overload
     def set_Haar_random_state(self) -> None: 
         """
-        Set Haar random state
-
         Set Haar random state
         """
     @typing.overload
@@ -883,11 +851,7 @@ class DensityMatrix(QuantumStateBase):
     @typing.overload
     def load(self, state: QuantumStateBase) -> None: 
         """
-        Load quantum state vector
-
         Load quantum state vector or density matrix
-
-        Load density matrix
         """
     @typing.overload
     def load(self, state: numpy.ndarray[numpy.complex128, _Shape[m, n]]) -> None: ...
@@ -905,16 +869,12 @@ class DensityMatrix(QuantumStateBase):
     def sampling(self, count: int) -> typing.List[int]: 
         """
         Sampling measurement results
-
-        Sampling measurement results
         """
     @typing.overload
     def sampling(self, count: int, seed: int) -> typing.List[int]: ...
     @typing.overload
     def set_Haar_random_state(self) -> None: 
         """
-        Set Haar random state
-
         Set Haar random state
         """
     @typing.overload

--- a/pysrc/qulacs/gate/__init__.pyi
+++ b/pysrc/qulacs/gate/__init__.pyi
@@ -69,8 +69,6 @@ __all__ = [
 def Adaptive(gate: qulacs_core.QuantumGateBase, condition: typing.Callable[[typing.List[int], int], bool], id: int) -> qulacs_core.QuantumGateBase:
     """
     Create adaptive gate
-
-    Create adaptive gate
     """
 @typing.overload
 def Adaptive(gate: qulacs_core.QuantumGateBase, condition: typing.Callable[[typing.List[int]], bool]) -> qulacs_core.QuantumGateBase:
@@ -102,8 +100,6 @@ def CZ(control: int, target: int) -> qulacs_core.QuantumGateBase:
 @typing.overload
 def DenseMatrix(index: int, matrix: numpy.ndarray[numpy.complex128, _Shape[m, n]]) -> qulacs_core.QuantumGateMatrix:
     """
-    Create dense matrix gate
-
     Create dense matrix gate
     """
 @typing.overload
@@ -205,8 +201,6 @@ def RZ(index: int, angle: float) -> qulacs_core.QuantumGateBase:
 def RandomUnitary(index_list: typing.List[int]) -> qulacs_core.QuantumGateMatrix:
     """
     Create random unitary gate
-
-    Create random unitary gate
     """
 @typing.overload
 def RandomUnitary(index_list: typing.List[int], seed: int) -> qulacs_core.QuantumGateMatrix:
@@ -288,9 +282,7 @@ def add(gate_list: typing.List[qulacs_core.QuantumGateBase]) -> qulacs_core.Quan
 @typing.overload
 def merge(gate1: qulacs_core.QuantumGateBase, gate2: qulacs_core.QuantumGateBase) -> qulacs_core.QuantumGateMatrix:
     """
-    Merge two quantum gate
-
-    Merge quantum gate list
+    Merge two quantum gate or gate list
     """
 @typing.overload
 def merge(gate_list: typing.List[qulacs_core.QuantumGateBase]) -> qulacs_core.QuantumGateMatrix:

--- a/pysrc/qulacs/state/__init__.pyi
+++ b/pysrc/qulacs/state/__init__.pyi
@@ -24,8 +24,6 @@ def inner_product(state_bra: qulacs_core.QuantumState, state_ket: qulacs_core.Qu
 def partial_trace(state: qulacs_core.DensityMatrix, target_traceout: typing.List[int]) -> qulacs_core.DensityMatrix:
     """
     Take partial trace
-
-    Take partial trace
     """
 @typing.overload
 def partial_trace(state: qulacs_core.QuantumState, target_traceout: typing.List[int]) -> qulacs_core.DensityMatrix:
@@ -34,8 +32,6 @@ def partial_trace(state: qulacs_core.QuantumState, target_traceout: typing.List[
 def permutate_qubit(state: qulacs_core.DensityMatrix, order: typing.List[int]) -> qulacs_core.DensityMatrix:
     """
     Permutate qubits from state
-
-    Permutate qubits from state
     """
 @typing.overload
 def permutate_qubit(state: qulacs_core.QuantumState, order: typing.List[int]) -> qulacs_core.QuantumState:
@@ -43,8 +39,6 @@ def permutate_qubit(state: qulacs_core.QuantumState, order: typing.List[int]) ->
 @typing.overload
 def tensor_product(state_left: qulacs_core.DensityMatrix, state_right: qulacs_core.DensityMatrix) -> qulacs_core.DensityMatrix:
     """
-    Get tensor product of states
-
     Get tensor product of states
     """
 @typing.overload

--- a/python/cppsim_wrapper.cpp
+++ b/python/cppsim_wrapper.cpp
@@ -67,7 +67,7 @@ PYBIND11_MODULE(qulacs_core, m) {
         .def(py::init<unsigned int>(), "Constructor", py::arg("qubit_count"))
         // .def(py::init<std::string>())
         .def("add_operator", (void (GeneralQuantumOperator::*)(const PauliOperator*)) &GeneralQuantumOperator::add_operator, "Add Pauli operator", py::arg("pauli_operator"))
-        .def("add_operator", (void (GeneralQuantumOperator::*)(std::complex<double> coef, std::string))&GeneralQuantumOperator::add_operator, "Add Pauli operator", py::arg("coef"), py::arg("pauli_string"))
+        .def("add_operator", (void (GeneralQuantumOperator::*)(std::complex<double> coef, std::string))&GeneralQuantumOperator::add_operator, py::arg("coef"), py::arg("pauli_string"))
         .def("is_hermitian", &GeneralQuantumOperator::is_hermitian, "Get is Herimitian")
         .def("get_qubit_count", &GeneralQuantumOperator::get_qubit_count, "Get qubit count")
         .def("get_state_dim", &GeneralQuantumOperator::get_state_dim, "Get state dimension")
@@ -108,7 +108,7 @@ PYBIND11_MODULE(qulacs_core, m) {
         .def(py::init<unsigned int>(), "Constructor", py::arg("qubit_count"))
         // .def(py::init<std::string>())
         .def("add_operator", (void (HermitianQuantumOperator::*)(const PauliOperator*)) &HermitianQuantumOperator::add_operator, "Add Pauli operator", py::arg("pauli_operator"))
-        .def("add_operator", (void (HermitianQuantumOperator::*)(std::complex<double> coef, std::string))&HermitianQuantumOperator::add_operator, "Add Pauli operator", py::arg("coef"), py::arg("string"))
+        .def("add_operator", (void (HermitianQuantumOperator::*)(std::complex<double> coef, std::string))&HermitianQuantumOperator::add_operator, py::arg("coef"), py::arg("string"))
         .def("get_qubit_count", &HermitianQuantumOperator::get_qubit_count, "Get qubit count")
         .def("get_state_dim", &HermitianQuantumOperator::get_state_dim, "Get state dimension")
         .def("get_term_count", &HermitianQuantumOperator::get_term_count, "Get count of Pauli terms")
@@ -126,7 +126,7 @@ PYBIND11_MODULE(qulacs_core, m) {
         .def("get_transition_amplitude", &HermitianQuantumOperator::get_transition_amplitude, "Get transition amplitude", py::arg("state_bra"), py::arg("state_ket"))
         //.def_static("get_split_Observable", &(HermitianQuantumOperator::get_split_observable));
         .def("add_random_operator", (void (GeneralQuantumOperator::*)(UINT))&HermitianQuantumOperator::add_random_operator, "Add random pauli operator", py::arg("operator_count"))
-        .def("add_random_operator", (void (GeneralQuantumOperator::*)(UINT, UINT))&HermitianQuantumOperator::add_random_operator, "Add random pauli operator", py::arg("operator_count"), py::arg("seed"))
+        .def("add_random_operator", (void (GeneralQuantumOperator::*)(UINT, UINT))&HermitianQuantumOperator::add_random_operator, "", py::arg("operator_count"), py::arg("seed"))
         .def("solve_ground_state_eigenvalue_by_arnoldi_method", &HermitianQuantumOperator::solve_ground_state_eigenvalue_by_arnoldi_method,
             "Compute ground state eigenvalue by arnoldi method", py::arg("state"), py::arg("iter_count"), py::arg("mu") = 0.0)
         .def("solve_ground_state_eigenvalue_by_power_method", &HermitianQuantumOperator::solve_ground_state_eigenvalue_by_power_method,
@@ -149,7 +149,7 @@ PYBIND11_MODULE(qulacs_core, m) {
         .def("set_zero_state", &QuantumState::set_zero_state, "Set state to |0>")
         .def("set_computational_basis", &QuantumState::set_computational_basis, "Set state to computational basis", py::arg("index"))
         .def("set_Haar_random_state", (void (QuantumState::*)(void))&QuantumState::set_Haar_random_state, "Set Haar random state")
-        .def("set_Haar_random_state", (void (QuantumState::*)(UINT))&QuantumState::set_Haar_random_state, "Set Haar random state", py::arg("seed"))
+        .def("set_Haar_random_state", (void (QuantumState::*)(UINT))&QuantumState::set_Haar_random_state, py::arg("seed"))
         .def("get_zero_probability", &QuantumState::get_zero_probability, "Get probability with which we obtain 0 when we measure a qubit", py::arg("index"))
         .def("get_marginal_probability", &QuantumState::get_marginal_probability, "Get merginal probability for measured values", py::arg("measured_value"))
         .def("get_entropy", &QuantumState::get_entropy, "Get entropy")
@@ -159,7 +159,7 @@ PYBIND11_MODULE(qulacs_core, m) {
         //.def("copy", &QuantumState::copy, pybind11::return_value_policy::automatic_reference)
         .def("copy", &QuantumState::copy, "Create copied instance")
         .def("load", (void (QuantumState::*)(const QuantumStateBase*))&QuantumState::load, "Load quantum state vector", py::arg("state"))
-        .def("load", (void (QuantumState::*)(const std::vector<CPPCTYPE>&))&QuantumState::load, "Load quantum state vector", py::arg("state"))
+        .def("load", (void (QuantumState::*)(const std::vector<CPPCTYPE>&))&QuantumState::load, py::arg("state"))
         .def("get_device_name", &QuantumState::get_device_name, "Get allocated device name")
         //.def("data_cpp", &QuantumState::data_cpp)
         //.def("data_c", &QuantumState::data_c)
@@ -170,7 +170,7 @@ PYBIND11_MODULE(qulacs_core, m) {
         .def("set_classical_value", &QuantumState::set_classical_value, "Set classical value", py::arg("index"), py::arg("value"))
         .def("to_string",&QuantumState::to_string, "Get string representation")
         .def("sampling", (std::vector<ITYPE> (QuantumState::*)(UINT))&QuantumState::sampling, "Sampling measurement results", py::arg("count"))
-        .def("sampling", (std::vector<ITYPE>(QuantumState::*)(UINT, UINT))&QuantumState::sampling, "Sampling measurement results", py::arg("count"), py::arg("seed"))
+        .def("sampling", (std::vector<ITYPE>(QuantumState::*)(UINT, UINT))&QuantumState::sampling, py::arg("count"), py::arg("seed"))
         .def("get_vector", [](const QuantumState& state) {
         Eigen::VectorXcd vec = Eigen::Map<Eigen::VectorXcd>(state.data_cpp(), state.dim);
         return vec;
@@ -192,7 +192,7 @@ PYBIND11_MODULE(qulacs_core, m) {
         .def("set_zero_state", &DensityMatrix::set_zero_state, "Set state to |0>")
         .def("set_computational_basis", &DensityMatrix::set_computational_basis, "Set state to computational basis", py::arg("index"))
         .def("set_Haar_random_state", (void (DensityMatrix::*)(void))&DensityMatrix::set_Haar_random_state, "Set Haar random state")
-        .def("set_Haar_random_state", (void (DensityMatrix::*)(UINT))&DensityMatrix::set_Haar_random_state, "Set Haar random state", py::arg("seed"))
+        .def("set_Haar_random_state", (void (DensityMatrix::*)(UINT))&DensityMatrix::set_Haar_random_state, py::arg("seed"))
         .def("get_zero_probability", &DensityMatrix::get_zero_probability, "Get probability with which we obtain 0 when we measure a qubit", py::arg("index"))
         .def("get_marginal_probability", &DensityMatrix::get_marginal_probability, "Get merginal probability for measured values", py::arg("measured_value"))
         .def("get_entropy", &DensityMatrix::get_entropy, "Get entropy")
@@ -200,9 +200,9 @@ PYBIND11_MODULE(qulacs_core, m) {
         .def("normalize", &DensityMatrix::normalize, "Normalize quantum state", py::arg("squared_norm"))
         .def("allocate_buffer", &DensityMatrix::allocate_buffer, pybind11::return_value_policy::automatic_reference, "Allocate buffer with the same size")
         .def("copy", &DensityMatrix::copy, "Create copied insntace")
-        .def("load", (void (DensityMatrix::*)(const QuantumStateBase*))&DensityMatrix::load, "Load quantum state vector", py::arg("state"))
-        .def("load", (void (DensityMatrix::*)(const std::vector<CPPCTYPE>&))&DensityMatrix::load, "Load quantum state vector or density matrix", py::arg("state"))
-        .def("load", (void (DensityMatrix::*)(const ComplexMatrix&))&DensityMatrix::load, "Load density matrix", py::arg("state"))
+        .def("load", (void (DensityMatrix::*)(const QuantumStateBase*))&DensityMatrix::load, "Load quantum state vector or density matrix", py::arg("state"))
+        .def("load", (void (DensityMatrix::*)(const std::vector<CPPCTYPE>&))&DensityMatrix::load, py::arg("state"))
+        .def("load", (void (DensityMatrix::*)(const ComplexMatrix&))&DensityMatrix::load, py::arg("state"))
         .def("get_device_name", &DensityMatrix::get_device_name, "Get allocated device name")
         //.def("data_cpp", &DensityMatrix::data_cpp)
         //.def("data_c", &DensityMatrix::data_c)
@@ -212,7 +212,7 @@ PYBIND11_MODULE(qulacs_core, m) {
         .def("set_classical_value", &DensityMatrix::set_classical_value, "Set classical value", py::arg("index"), py::arg("value"))
         .def("to_string", &QuantumState::to_string, "Get string representation")
         .def("sampling", (std::vector<ITYPE>(DensityMatrix::*)(UINT))&DensityMatrix::sampling, "Sampling measurement results", py::arg("count"))
-        .def("sampling", (std::vector<ITYPE>(DensityMatrix::*)(UINT, UINT))&DensityMatrix::sampling, "Sampling measurement results", py::arg("count"), py::arg("seed"))
+        .def("sampling", (std::vector<ITYPE>(DensityMatrix::*)(UINT, UINT))&DensityMatrix::sampling, py::arg("count"), py::arg("seed"))
 
         .def("get_matrix", [](const DensityMatrix& state) {
             Eigen::MatrixXcd mat(state.dim, state.dim);
@@ -234,7 +234,7 @@ PYBIND11_MODULE(qulacs_core, m) {
         .def("set_zero_state", &QuantumStateGpu::set_zero_state, "Set state to |0>")
         .def("set_computational_basis", &QuantumStateGpu::set_computational_basis, "Set state to computational basis", py::arg("index"))
         .def("set_Haar_random_state", (void (QuantumStateGpu::*)(void))&QuantumStateGpu::set_Haar_random_state, "Set Haar random state")
-        .def("set_Haar_random_state", (void (QuantumStateGpu::*)(UINT))&QuantumStateGpu::set_Haar_random_state, "Set Haar random state", py::arg("seed"))
+        .def("set_Haar_random_state", (void (QuantumStateGpu::*)(UINT))&QuantumStateGpu::set_Haar_random_state, py::arg("seed"))
         .def("get_zero_probability", &QuantumStateGpu::get_zero_probability, "Get probability with which we obtain 0 when we measure a qubit", py::arg("index"))
         .def("get_marginal_probability", &QuantumStateGpu::get_marginal_probability, "Get merginal probability for measured values", py::arg("measured_value"))
         .def("get_entropy", &QuantumStateGpu::get_entropy, "Get entropy")
@@ -244,7 +244,7 @@ PYBIND11_MODULE(qulacs_core, m) {
         //.def("copy", &QuantumStateGpu::copy, pybind11::return_value_policy::automatic_reference)
         .def("copy", &QuantumStateGpu::copy, "Create copied insntace")
         .def("load", (void (QuantumStateGpu::*)(const QuantumStateBase*))&QuantumStateGpu::load, "Load quantum state vector", py::arg("state"))
-        .def("load", (void (QuantumStateGpu::*)(const std::vector<CPPCTYPE>&))&QuantumStateGpu::load, "Load quantum state vector", py::arg("state"))
+        .def("load", (void (QuantumStateGpu::*)(const std::vector<CPPCTYPE>&))&QuantumStateGpu::load, py::arg("state"))
         .def("get_device_name", &QuantumStateGpu::get_device_name, "Get allocated device name")
         //.def("data_cpp", &QuantumStateGpu::data_cpp)
         //.def("data_c", &QuantumStateGpu::data_c)
@@ -255,7 +255,7 @@ PYBIND11_MODULE(qulacs_core, m) {
         .def("set_classical_value", &QuantumStateGpu::set_classical_value, "Set classical value", py::arg("index"), py::arg("value"))
         .def("to_string", &QuantumStateGpu::to_string, "Get string representation")
         .def("sampling", (std::vector<ITYPE>(QuantumStateGpu::*)(UINT))&QuantumStateGpu::sampling, "Sampling measurement results", py::arg("count"))
-        .def("sampling", (std::vector<ITYPE>(QuantumStateGpu::*)(UINT, UINT))&QuantumStateGpu::sampling, "Sampling measurement results", py::arg("count"), py::arg("seed"))
+        .def("sampling", (std::vector<ITYPE>(QuantumStateGpu::*)(UINT, UINT))&QuantumStateGpu::sampling, py::arg("count"), py::arg("seed"))
         .def("get_vector", [](const QuantumStateGpu& state) {
             Eigen::VectorXcd vec = Eigen::Map<Eigen::VectorXcd>(state.duplicate_data_cpp(), state.dim);
             return vec;
@@ -298,8 +298,7 @@ PYBIND11_MODULE(qulacs_core, m) {
     mstate.def("tensor_product",
         py::overload_cast<const DensityMatrix *, const DensityMatrix *>(
             &state::tensor_product),
-        pybind11::return_value_policy::take_ownership,
-        "Get tensor product of states", py::arg("state_left"),
+        pybind11::return_value_policy::take_ownership, py::arg("state_left"),
         py::arg("state_right"));
     mstate.def("permutate_qubit",
         py::overload_cast<const QuantumState *, std::vector<UINT>>(
@@ -309,8 +308,7 @@ PYBIND11_MODULE(qulacs_core, m) {
     mstate.def("permutate_qubit",
         py::overload_cast<const DensityMatrix *, std::vector<UINT>>(
             &state::permutate_qubit),
-        pybind11::return_value_policy::take_ownership,
-        "Permutate qubits from state", py::arg("state"), py::arg("order"));
+        pybind11::return_value_policy::take_ownership, py::arg("state"), py::arg("order"));
 
     mstate.def("drop_qubit", &state::drop_qubit,
         pybind11::return_value_policy::take_ownership, "Drop qubits from state",
@@ -323,7 +321,7 @@ PYBIND11_MODULE(qulacs_core, m) {
     mstate.def("partial_trace",
         py::overload_cast<const DensityMatrix *, std::vector<UINT>>(
             &state::partial_trace),
-        pybind11::return_value_policy::take_ownership, "Take partial trace",
+        pybind11::return_value_policy::take_ownership,
         py::arg("state"), py::arg("target_traceout"));
 
     py::class_<QuantumGateBase>(m, "QuantumGateBase")
@@ -448,7 +446,7 @@ PYBIND11_MODULE(qulacs_core, m) {
         auto ptr = gate::DenseMatrix(target_qubit_index_list, matrix);
         if (ptr == NULL) throw std::invalid_argument("Invalid argument passed to DenseMatrix.");
         return ptr;
-    }, pybind11::return_value_policy::take_ownership, "Create dense matrix gate", py::arg("index_list"), py::arg("matrix")); 
+    }, pybind11::return_value_policy::take_ownership, py::arg("index_list"), py::arg("matrix")); 
     mgate.def("SparseMatrix", [](std::vector<unsigned int> target_qubit_index_list, SparseComplexMatrix matrix) {
         const ITYPE dim = 1ULL << target_qubit_index_list.size();
         if (matrix.rows() != dim || matrix.cols() != dim) throw std::invalid_argument("matrix dims is not consistent.");
@@ -473,7 +471,7 @@ PYBIND11_MODULE(qulacs_core, m) {
         auto ptr = gate::RandomUnitary(target_qubit_index_list, seed);
         if (ptr == NULL) throw std::invalid_argument("Invalid argument passed to RandomUnitary.");
         return ptr;
-    }, pybind11::return_value_policy::take_ownership, "Create random unitary gate", py::arg("index_list"), py::arg("seed")); 
+    }, pybind11::return_value_policy::take_ownership, py::arg("index_list"), py::arg("seed")); 
     mgate.def("ReversibleBoolean", [](std::vector<UINT> target_qubit_list, std::function<ITYPE(ITYPE,ITYPE)> function_py) {
         auto ptr = gate::ReversibleBoolean(target_qubit_list, function_py);
         if (ptr == NULL) throw std::invalid_argument("Invalid argument passed to ReversibleBoolean.");
@@ -498,10 +496,10 @@ PYBIND11_MODULE(qulacs_core, m) {
     mgate.def("Measurement", &gate::Measurement, pybind11::return_value_policy::take_ownership, "Create measurement gate", py::arg("index"), py::arg("register"));
 
     QuantumGateMatrix*(*ptr3)(const QuantumGateBase*, const QuantumGateBase*) = &gate::merge;
-    mgate.def("merge", ptr3, pybind11::return_value_policy::take_ownership, "Merge two quantum gate", py::arg("gate1"), py::arg("gate2"));
+    mgate.def("merge", ptr3, pybind11::return_value_policy::take_ownership, "Merge two quantum gate or gate list", py::arg("gate1"), py::arg("gate2"));
 
     QuantumGateMatrix*(*ptr4)(std::vector<const QuantumGateBase*>) = &gate::merge;
-    mgate.def("merge", ptr4, pybind11::return_value_policy::take_ownership, "Merge quantum gate list", py::arg("gate_list"));
+    mgate.def("merge", ptr4, pybind11::return_value_policy::take_ownership, py::arg("gate_list"));
 
     QuantumGateMatrix*(*ptr5)(const QuantumGateBase*, const QuantumGateBase*) = &gate::add;
     mgate.def("add", ptr5, pybind11::return_value_policy::take_ownership, "Add quantum gate matrices", py::arg("gate1"), py::arg("gate2"));
@@ -516,7 +514,7 @@ PYBIND11_MODULE(qulacs_core, m) {
     mgate.def("CP", &gate::CP, pybind11::return_value_policy::take_ownership, "Create completely-positive map", py::arg("kraus_list"), py::arg("state_normalize"), py::arg("probability_normalize"), py::arg("assign_zero_if_not_matched"));
     mgate.def("Instrument", &gate::Instrument, pybind11::return_value_policy::take_ownership, "Create instruments", py::arg("kraus_list"), py::arg("register"));
     mgate.def("Adaptive", py::overload_cast<QuantumGateBase *, std::function<bool(const std::vector<unsigned int>&)>> (&gate::Adaptive), pybind11::return_value_policy::take_ownership, "Create adaptive gate", py::arg("gate"), py::arg("condition"));
-    mgate.def("Adaptive",  py::overload_cast<QuantumGateBase *, std::function<bool(const std::vector<unsigned int>&, unsigned int)>, unsigned int> (&gate::Adaptive), pybind11::return_value_policy::take_ownership, "Create adaptive gate", py::arg("gate"), py::arg("condition"),py::arg("id"));
+    mgate.def("Adaptive",  py::overload_cast<QuantumGateBase *, std::function<bool(const std::vector<unsigned int>&, unsigned int)>, unsigned int> (&gate::Adaptive), pybind11::return_value_policy::take_ownership, py::arg("gate"), py::arg("condition"),py::arg("id"));
     mgate.def("NoisyEvolution", &gate::NoisyEvolution, pybind11::return_value_policy::take_ownership, "Create noisy evolution", py::arg("hamiltonian"), py::arg("c_ops"), py::arg("time"), py::arg("dt"));
 
     py::class_<QuantumGate_SingleParameter, QuantumGateBase>(m, "QuantumGate_SingleParameter")
@@ -540,7 +538,7 @@ PYBIND11_MODULE(qulacs_core, m) {
         //.def("add_gate_consume", (void (QuantumCircuit::*)(QuantumGateBase*))&QuantumCircuit::add_gate, "Add gate and take ownership", py::arg("gate"))
         //.def("add_gate_consume", (void (QuantumCircuit::*)(QuantumGateBase*, unsigned int))&QuantumCircuit::add_gate, "Add gate and take ownership", py::arg("gate"), py::arg("position"))
         .def("add_gate", (void (QuantumCircuit::*)(const QuantumGateBase*))&QuantumCircuit::add_gate_copy, "Add gate with copy", py::arg("gate"))
-        .def("add_gate", (void (QuantumCircuit::*)(const QuantumGateBase*, unsigned int))&QuantumCircuit::add_gate_copy, "Add gate with copy", py::arg("gate"), py::arg("position"))
+        .def("add_gate", (void (QuantumCircuit::*)(const QuantumGateBase*, unsigned int))&QuantumCircuit::add_gate_copy, py::arg("gate"), py::arg("position"))
         .def("add_noise_gate",&QuantumCircuit::add_noise_gate_copy,"Add noise gate with copy", py::arg("gate"),py::arg("NoiseType"),py::arg("NoiseProbability"))
         .def("remove_gate", &QuantumCircuit::remove_gate, "Remove gate", py::arg("position"))
 
@@ -556,7 +554,7 @@ PYBIND11_MODULE(qulacs_core, m) {
         .def("get_qubit_count", [](const QuantumCircuit& circuit) -> unsigned int {return circuit.qubit_count;}, "Get qubit count")
 
         .def("update_quantum_state", (void (QuantumCircuit::*)(QuantumStateBase*))&QuantumCircuit::update_quantum_state, "Update quantum state", py::arg("state"))
-        .def("update_quantum_state", (void (QuantumCircuit::*)(QuantumStateBase*, unsigned int, unsigned int))&QuantumCircuit::update_quantum_state, "Update quantum state", py::arg("state"), py::arg("start"), py::arg("end"))
+        .def("update_quantum_state", (void (QuantumCircuit::*)(QuantumStateBase*, unsigned int, unsigned int))&QuantumCircuit::update_quantum_state, py::arg("state"), py::arg("start"), py::arg("end"))
         .def("calculate_depth", &QuantumCircuit::calculate_depth, "Calculate depth of circuit")
         .def("to_string", &QuantumCircuit::to_string, "Get string representation")
 
@@ -587,13 +585,13 @@ PYBIND11_MODULE(qulacs_core, m) {
         .def("add_U3_gate", &QuantumCircuit::add_U3_gate, "Add QASM U3 gate", py::arg("index"), py::arg("theta"), py::arg("phi"), py::arg("lambda"))
 
         .def("add_multi_Pauli_gate", (void (QuantumCircuit::*)(std::vector<unsigned int>, std::vector<unsigned int>))&QuantumCircuit::add_multi_Pauli_gate, "Add multi-qubit Pauli gate", py::arg("index_list"), py::arg("pauli_ids"))
-        .def("add_multi_Pauli_gate", (void (QuantumCircuit::*)(const PauliOperator&)) &QuantumCircuit::add_multi_Pauli_gate, "Add multi-qubit Pauli gate", py::arg("pauli"))
+        .def("add_multi_Pauli_gate", (void (QuantumCircuit::*)(const PauliOperator&)) &QuantumCircuit::add_multi_Pauli_gate, py::arg("pauli"))
         .def("add_multi_Pauli_rotation_gate", (void (QuantumCircuit::*)(std::vector<unsigned int>, std::vector<unsigned int>, double))&QuantumCircuit::add_multi_Pauli_rotation_gate, "Add multi-qubit Pauli rotation gate", py::arg("index_list"), py::arg("pauli_ids"), py::arg("angle"))
-        .def("add_multi_Pauli_rotation_gate", (void (QuantumCircuit::*)(const PauliOperator&))&QuantumCircuit::add_multi_Pauli_rotation_gate, "Add multi-qubit Pauli gate", py::arg("pauli"))
+        .def("add_multi_Pauli_rotation_gate", (void (QuantumCircuit::*)(const PauliOperator&))&QuantumCircuit::add_multi_Pauli_rotation_gate, py::arg("pauli"))
         .def("add_dense_matrix_gate", (void (QuantumCircuit::*)(unsigned int, const ComplexMatrix&))&QuantumCircuit::add_dense_matrix_gate, "Add dense matrix gate", py::arg("index"), py::arg("matrix"))
-        .def("add_dense_matrix_gate", (void (QuantumCircuit::*)(std::vector<unsigned int>, const ComplexMatrix&))&QuantumCircuit::add_dense_matrix_gate, "Add dense matrix gate", py::arg("index_list"), py::arg("matrix"))
+        .def("add_dense_matrix_gate", (void (QuantumCircuit::*)(std::vector<unsigned int>, const ComplexMatrix&))&QuantumCircuit::add_dense_matrix_gate, py::arg("index_list"), py::arg("matrix"))
         .def("add_random_unitary_gate", (void (QuantumCircuit::*)(std::vector<UINT>))&QuantumCircuit::add_random_unitary_gate, "Add random unitary gate", py::arg("index_list"))
-        .def("add_random_unitary_gate", (void (QuantumCircuit::*)(std::vector<UINT>, UINT))&QuantumCircuit::add_random_unitary_gate, "Add random unitary gate", py::arg("index_list"), py::arg("seed"))
+        .def("add_random_unitary_gate", (void (QuantumCircuit::*)(std::vector<UINT>, UINT))&QuantumCircuit::add_random_unitary_gate, py::arg("index_list"), py::arg("seed"))
         .def("add_diagonal_observable_rotation_gate", &QuantumCircuit::add_diagonal_observable_rotation_gate, "Add diagonal observable rotation gate", py::arg("observable"), py::arg("angle"))
         .def("add_observable_rotation_gate", &QuantumCircuit::add_observable_rotation_gate, "Add observable rotation gate", py::arg("observable"), py::arg("angle"), py::arg("repeat"))
             
@@ -604,9 +602,9 @@ PYBIND11_MODULE(qulacs_core, m) {
         .def(py::init<unsigned int>(), "Constructor", py::arg("qubit_count"))
         .def("copy", &ParametricQuantumCircuit::copy, pybind11::return_value_policy::take_ownership, "Create copied instance")      
         .def("add_parametric_gate", (void (ParametricQuantumCircuit::*)(QuantumGate_SingleParameter* gate))  &ParametricQuantumCircuit::add_parametric_gate_copy, "Add parametric gate", py::arg("gate"))
-        .def("add_parametric_gate", (void (ParametricQuantumCircuit::*)(QuantumGate_SingleParameter* gate, UINT))  &ParametricQuantumCircuit::add_parametric_gate_copy, "Add parametric gate", py::arg("gate"), py::arg("position"))
+        .def("add_parametric_gate", (void (ParametricQuantumCircuit::*)(QuantumGate_SingleParameter* gate, UINT))  &ParametricQuantumCircuit::add_parametric_gate_copy, py::arg("gate"), py::arg("position"))
         .def("add_gate", (void (ParametricQuantumCircuit::*)(const QuantumGateBase* gate))  &ParametricQuantumCircuit::add_gate_copy, "Add gate", py::arg("gate"))
-        .def("add_gate", (void (ParametricQuantumCircuit::*)(const QuantumGateBase* gate, unsigned int))  &ParametricQuantumCircuit::add_gate_copy, "Add gate", py::arg("gate"), py::arg("position"))
+        .def("add_gate", (void (ParametricQuantumCircuit::*)(const QuantumGateBase* gate, unsigned int))  &ParametricQuantumCircuit::add_gate_copy, py::arg("gate"), py::arg("position"))
         .def("get_parameter_count", &ParametricQuantumCircuit::get_parameter_count, "Get parameter count")
         .def("get_parameter", &ParametricQuantumCircuit::get_parameter, "Get parameter", py::arg("index"))
         .def("set_parameter", &ParametricQuantumCircuit::set_parameter, "Set parameter", py::arg("index"), py::arg("parameter"))
@@ -626,8 +624,8 @@ PYBIND11_MODULE(qulacs_core, m) {
     
     py::class_<GradCalculator>(m, "GradCalculator")
         .def(py::init<>())
-        .def("calculate_grad",py::overload_cast<ParametricQuantumCircuit&, Observable&>(&GradCalculator::calculate_grad),"Calculate Grad",py::arg("parametric_circuit"),py::arg("observable"))
-        .def("calculate_grad",py::overload_cast<ParametricQuantumCircuit&, Observable&,std::vector<double>>(&GradCalculator::calculate_grad),"Calculate Grad",py::arg("parametric_circuit"),py::arg("observable"),py::arg("angles of gates"));
+        .def("calculate_grad",py::overload_cast<ParametricQuantumCircuit&, Observable&>(&GradCalculator::calculate_grad),"Calculate Grad", py::arg("parametric_circuit"),py::arg("observable"))
+        .def("calculate_grad",py::overload_cast<ParametricQuantumCircuit&, Observable&,std::vector<double>>(&GradCalculator::calculate_grad), py::arg("parametric_circuit"),py::arg("observable"),py::arg("angles of gates"));
        
     auto mcircuit = m.def_submodule("circuit");
     py::class_<QuantumCircuitOptimizer>(mcircuit, "QuantumCircuitOptimizer")
@@ -641,7 +639,7 @@ PYBIND11_MODULE(qulacs_core, m) {
         .def(py::init<QuantumCircuit*, QuantumStateBase*>(), "Constructor", py::arg("circuit"), py::arg("state"))
         .def("initialize_state", &QuantumCircuitSimulator::initialize_state, "Initialize state")
         .def("initialize_random_state", (void (QuantumCircuitSimulator::*)(void))&QuantumCircuitSimulator::initialize_random_state, "Initialize state with random pure state")
-        .def("initialize_random_state", (void (QuantumCircuitSimulator::*)(UINT))&QuantumCircuitSimulator::initialize_random_state, "Initialize state with random pure state", py::arg("seed"))
+        .def("initialize_random_state", (void (QuantumCircuitSimulator::*)(UINT))&QuantumCircuitSimulator::initialize_random_state, py::arg("seed"))
         .def("simulate", &QuantumCircuitSimulator::simulate, "Simulate circuit")
         .def("simulate_range", &QuantumCircuitSimulator::simulate_range, "Simulate circuit", py::arg("start"), py::arg("end"))
         .def("get_expectation_value", &QuantumCircuitSimulator::get_expectation_value, "Get expectation value", py::arg("observable"))


### PR DESCRIPTION
close #292 
オーバーロードした関数にpybind11からドキュメントコメントを付けるとき、2箇所ともに書くとなぜか2行にわたって同じことが書かれてしまうので片方だけに寄せました。
引数に寄ってコメントを変えてみたかったのですがstubのそれぞれのdefの下にコメントを書くようにしてもうまく動作しなかったのでstubの仕様に問題があると思っています