### PR TITLE
enable to use pybind11 in devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -71,3 +71,8 @@ RUN git clone https://gitlab.com/libeigen/eigen.git -b 3.3.7 --depth 1 /tmp/eige
 RUN git clone https://github.com/google/googletest.git -b release-1.8.1 --depth 1 /tmp/gtest \
     && cp -r /tmp/gtest/googletest/include/gtest /usr/local/include \
     && rm -rf /tmp/gtest
+
+# Install pybind11
+RUN git clone https://github.com/pybind/pybind11.git -b v2.7.1 --depth 1 /tmp/pybind11 \
+    && cp -r /tmp/pybind11/include/pybind11 /usr/local/include \
+    && rm -rf /tmp/pybind11

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -30,7 +30,8 @@
 		"python.terminal.activateEnvironment": false,
 		// CAVEAT: you need to restart after building qulacs-osaka to take effect.
 		"C_Cpp.default.includePath": [
-			"include"
+			"include",
+			"/.pyenv/versions/${PYTHON_VERSION}/include/python3.9"
 		]
 	},
 	// Add the IDs of extensions you want installed when the container is created.


### PR DESCRIPTION
close #293
似たようなPRを既に2回やったのですがまた同じような感じで、cpppsim_wrapperを快適に書けるようにpybind11をdevcontainerにインストールしたりPython.hがインクルードできるようにしたりしました。