### PR TITLE
refactoring cppsim by KowerKoint

### DIFF
--- a/src/cppsim/gate_matrix_diagonal.cpp
+++ b/src/cppsim/gate_matrix_diagonal.cpp
@@ -86,8 +86,8 @@ void QuantumGateDiagonalMatrix::update_quantum_state(QuantumStateBase* state) {
     if (state->is_state_vector()) {
 #ifdef _USE_GPU
         if (state->get_device_name() == "gpu") {
-            std::cerr << "Diagonal matrix gate is not supported on GPU"
-                      << std::endl;
+            throw NotImplementedException(
+                "Diagonal matrix gate is not supported on GPU");
         } else {
             if (control_index.size() == 0) {
                 if (target_index.size() == 1) {
@@ -125,7 +125,9 @@ void QuantumGateDiagonalMatrix::update_quantum_state(QuantumStateBase* state) {
         }
 #endif
     } else {
-        std::cerr << "not implemented" << std::endl;
+        throw NotImplementedException(
+            "QuantumGateDiagonalMatrix::update_quantum_state for density "
+            "matrix is not implemented");
     }
 }
 

--- a/src/cppsim/gate_matrix_diagonal.cpp
+++ b/src/cppsim/gate_matrix_diagonal.cpp
@@ -69,11 +69,6 @@ QuantumGateDiagonalMatrix::QuantumGateDiagonalMatrix(
 void QuantumGateDiagonalMatrix::update_quantum_state(QuantumStateBase* state) {
     ITYPE dim = 1ULL << state->qubit_count;
 
-    if (this->_control_qubit_list.size() > 0) {
-        std::cerr << "Control qubit in sparse matrix gate is not supported"
-                  << std::endl;
-    }
-
     const CTYPE* diagonal_ptr =
         reinterpret_cast<const CTYPE*>(this->_diagonal_element.data());
     // convert list of QubitInfo to list of UINT

--- a/src/cppsim/gate_matrix_sparse.cpp
+++ b/src/cppsim/gate_matrix_sparse.cpp
@@ -71,7 +71,7 @@ void QuantumGateSparseMatrix::update_quantum_state(QuantumStateBase* state) {
     ITYPE dim = 1ULL << state->qubit_count;
 
     if (this->_control_qubit_list.size() > 0) {
-        throw InvalidControlQubitException(
+        throw NotImplementedException(
             "Control qubit in sparse matrix gate is not supported");
     }
 
@@ -96,7 +96,9 @@ void QuantumGateSparseMatrix::update_quantum_state(QuantumStateBase* state) {
             dim);
 #endif
     } else {
-        throw NotImplementedException("not implemented");
+        throw NotImplementedException(
+            "QuantumGateSparseMatrix::update_quantum_state for density "
+            "matrix is not implemented");
     }
 }
 

--- a/src/cppsim/pauli_operator.cpp
+++ b/src/cppsim/pauli_operator.cpp
@@ -254,7 +254,7 @@ std::string PauliOperator::get_pauli_string() const {
     UINT size = _pauli_list.size();
     UINT target_index, pauli_id;
     if (size == 0) {
-        return "I";
+        return "";
     }
     for (UINT index = 0; index < size; index++) {
         target_index = _pauli_list[index].index();

--- a/src/cppsim/pauli_operator.cpp
+++ b/src/cppsim/pauli_operator.cpp
@@ -52,6 +52,7 @@ PauliOperator::PauliOperator(const std::vector<UINT>& target_qubit_list,
     std::string Pauli_operator_type_list, CPPCTYPE coef)
     : _coef(coef) {
     UINT term_count = (UINT)(strlen(Pauli_operator_type_list.c_str()));
+    assert((UINT)target_qubit_list.size() == term_count);
     UINT pauli_type = 0;
     for (UINT term_index = 0; term_index < term_count; ++term_index) {
         if (Pauli_operator_type_list[term_index] == 'i' ||

--- a/src/cppsim/qubit_info.hpp
+++ b/src/cppsim/qubit_info.hpp
@@ -95,7 +95,7 @@ public:
  */
 class DllExport TargetQubitInfo : public QubitInfo {
 private:
-    // \~japanese-en この量子ビットがパウリ演算子と可換か同課を保持する値
+    // \~japanese-en この量子ビットがパウリ演算子と可換かどうかを保持する値
     UINT _commutation_property;
 
 public:

--- a/src/cppsim/state_dm.hpp
+++ b/src/cppsim/state_dm.hpp
@@ -365,8 +365,8 @@ public:
     virtual void multiply_elementwise_function(
         const std::function<CPPCTYPE(ITYPE)>&) override {
         throw NotImplementedException(
-            "multiply_elementwise_function between density matrix and "
-            "state vector is not implemented");
+            "multiply_elementwise_function for density matrix is not "
+            "implemented");
     }
 
     /**

--- a/src/cppsim/utility.cpp
+++ b/src/cppsim/utility.cpp
@@ -128,11 +128,12 @@ std::tuple<double, double, std::string> parse_openfermion_line(
     return std::make_tuple(coef_real, coef_imag, str_buf);
 }
 
-bool check_is_unique_index_list(std::vector<UINT> index_list) {
-    sort(index_list.begin(), index_list.end());
+bool check_is_unique_index_list(const std::vector<UINT>& index_list) {
+    std::vector<UINT> index_list_sorted(index_list.begin(), index_list.end());
+    sort(index_list_sorted.begin(), index_list_sorted.end());
     bool flag = true;
-    for (UINT i = 0; i + 1 < index_list.size(); ++i) {
-        flag = flag & (index_list[i] != index_list[i + 1]);
+    for (UINT i = 0; i + 1 < index_list_sorted.size(); ++i) {
+        flag = flag & (index_list_sorted[i] != index_list_sorted[i + 1]);
         if (!flag) break;
     }
     return flag;

--- a/src/cppsim/utility.cpp
+++ b/src/cppsim/utility.cpp
@@ -131,12 +131,12 @@ std::tuple<double, double, std::string> parse_openfermion_line(
 bool check_is_unique_index_list(const std::vector<UINT>& index_list) {
     std::vector<UINT> index_list_sorted(index_list.begin(), index_list.end());
     sort(index_list_sorted.begin(), index_list_sorted.end());
-    bool flag = true;
+    bool is_unique = true;
     for (UINT i = 0; i + 1 < index_list_sorted.size(); ++i) {
-        flag = flag & (index_list_sorted[i] != index_list_sorted[i + 1]);
-        if (!flag) break;
+        is_unique &= (index_list_sorted[i] != index_list_sorted[i + 1]);
+        if (!is_unique) break;
     }
-    return flag;
+    return is_unique;
 }
 
 std::string& rtrim(std::string& str) {

--- a/src/cppsim/utility.hpp
+++ b/src/cppsim/utility.hpp
@@ -212,7 +212,7 @@ DllExport std::tuple<double, double, std::string> parse_openfermion_line(
  * @param[in] index_list チェックする配列
  * @return 重複がある場合にtrue、ない場合にfalse
  */
-bool check_is_unique_index_list(std::vector<UINT> index_list);
+bool check_is_unique_index_list(const std::vector<UINT>& index_list);
 
 /**
  * \~japanese-en 与えられた文字列の末尾の空白文字を削除します。

--- a/test/cppsim/test_noisyevolution.cpp
+++ b/test/cppsim/test_noisyevolution.cpp
@@ -139,7 +139,7 @@ TEST(NoisyEvolutionTest, EffectiveHamiltonian) {
     auto gate = dynamic_cast<ClsNoisyEvolution*>(
         gate::NoisyEvolution(&hamiltonian, c_ops, time, dt));
     ASSERT_EQ(gate->get_effective_hamiltonian()->to_string(),
-        "(1,0) Z 0 Z 1 + (0,-1) I");
+        "(1,0) Z 0 Z 1 + (0,-1) ");
 }
 
 TEST(NoisyEvolutionTest, dephasing) {

--- a/test/cppsim/test_pauli_operator.cpp
+++ b/test/cppsim/test_pauli_operator.cpp
@@ -11,6 +11,13 @@ TEST(PauliOperatorTest, ContainsExtraWhitespace) {
     EXPECT_EQ(expected.get_pauli_string(), pauli_whitespace.get_pauli_string());
 }
 
+TEST(PauliOperatorTest, EmptyStringConstructsIdentity) {
+    const auto identity = PauliOperator("", 1.0);
+    ASSERT_EQ(0, identity.get_index_list().size());
+    ASSERT_EQ(0, identity.get_pauli_id_list().size());
+    ASSERT_EQ("", identity.get_pauli_string());
+}
+
 struct PauliTestParam {
     std::string test_name;
     PauliOperator op1;


### PR DESCRIPTION
cppsimの全コードを見直しています。
小さな修正が溜まってきたので一旦Pull Requestを送らせてもらいます。
基本的に通常の使用法で後方互換性は維持されるようにしているので「そもそも設計をやり直したい」みたいなのは無視しています。

1. DensityMatrixCpu::multiply_elementwise()のNotImplementedExceptionのメッセージが間違ってた
2. TargetQubitInfoのメンバのコメントが変換ミス
3. PauliOperatorのコンストラクタにassertを追加
4. PauliOperator::get_pauli_string()で`"I"`を返していた部分を`""`に変更(**仕様変更**)
5. check_is_unique_index_list()を呼び出すと引数のvectorがソートされるのをやめた、型も`const vector<UINT>&`になった(**仕様変更**)
  - control_qubit_indexとcontrol_qubit_valueを同時に渡すときなどで順番を意識することがあり、そこで混乱したくない
6. QuantumGateDiagonalMatrix::update_qantum_state()で間違った警告(sparse matrixからのコピー？)を出力してたので削除
7. DiagonalMatrixとSparseMatrixでNotImplementedExceptionを正しく利用