### PR TITLE
Comment encode fix

### DIFF
--- a/src/cppsim/circuit.hpp
+++ b/src/cppsim/circuit.hpp
@@ -138,12 +138,6 @@ public:
      * @param[in] circuit マージする量子回路
      */
     virtual void merge_circuit(const QuantumCircuit* circuit) {
-        if (this->qubit_count != circuit->qubit_count) {
-            throw InvalidQubitCountException(
-                "Error: "
-                "QuantumCircuit::add_circuit(QuantumCircuit*):"
-                "Qubit count doesn't match!");
-        }
         for (auto gate : circuit->gate_list) {
             this->add_gate_copy(gate);
         }

--- a/src/cppsim/gate_general.hpp
+++ b/src/cppsim/gate_general.hpp
@@ -34,6 +34,7 @@ public:
             std::back_inserter(_gate_list),
             [](auto gate) { return gate->copy(); });
         FLAG_NOISE = true;
+        this->_name = "Probabilistic";
     };
 
     virtual ~QuantumGate_Probabilistic() {
@@ -177,6 +178,8 @@ public:
         std::transform(gate_list.cbegin(), gate_list.cend(),
             std::back_inserter(_gate_list),
             [](auto gate) { return gate->copy(); });
+        FLAG_NOISE = true;
+        this->_name = "ProbabilisticInstrument";
     };
 
     virtual ~QuantumGate_ProbabilisticInstrument() {
@@ -244,6 +247,7 @@ public:
         std::transform(gate_list.cbegin(), gate_list.cend(),
             std::back_inserter(_gate_list),
             [](auto gate) { return gate->copy(); });
+        this->_name = "CPTP";
     };
     virtual ~QuantumGate_CPTP() {
         for (unsigned int i = 0; i < _gate_list.size(); ++i) {
@@ -349,6 +353,7 @@ public:
         std::transform(gate_list.cbegin(), gate_list.cend(),
             std::back_inserter(_gate_list),
             [](auto gate) { return gate->copy(); });
+        this->_name = "CP";
     };
     virtual ~QuantumGate_CP() {
         for (unsigned int i = 0; i < _gate_list.size(); ++i) {
@@ -467,6 +472,7 @@ public:
         std::transform(gate_list.cbegin(), gate_list.cend(),
             std::back_inserter(_gate_list),
             [](auto gate) { return gate->copy(); });
+        this->_name = "Instrument";
     };
     virtual ~QuantumGate_Instrument() {
         for (unsigned int i = 0; i < _gate_list.size(); ++i) {
@@ -555,7 +561,9 @@ public:
         UINT id)
         : _gate(gate->copy()),
           _func_with_id(func_with_id),
-          _id(static_cast<int>(id)){};
+          _id(static_cast<int>(id)) {
+        this->_name = "Adaptive";
+    };
     virtual ~QuantumGate_Adaptive() { delete _gate; }
 
     /**

--- a/src/cppsim/gate_matrix_diagonal.cpp
+++ b/src/cppsim/gate_matrix_diagonal.cpp
@@ -69,11 +69,6 @@ QuantumGateDiagonalMatrix::QuantumGateDiagonalMatrix(
 void QuantumGateDiagonalMatrix::update_quantum_state(QuantumStateBase* state) {
     ITYPE dim = 1ULL << state->qubit_count;
 
-    if (this->_control_qubit_list.size() > 0) {
-        std::cerr << "Control qubit in sparse matrix gate is not supported"
-                  << std::endl;
-    }
-
     const CTYPE* diagonal_ptr =
         reinterpret_cast<const CTYPE*>(this->_diagonal_element.data());
     // convert list of QubitInfo to list of UINT
@@ -91,8 +86,8 @@ void QuantumGateDiagonalMatrix::update_quantum_state(QuantumStateBase* state) {
     if (state->is_state_vector()) {
 #ifdef _USE_GPU
         if (state->get_device_name() == "gpu") {
-            std::cerr << "Diagonal matrix gate is not supported on GPU"
-                      << std::endl;
+            throw NotImplementedException(
+                "Diagonal matrix gate is not supported on GPU");
         } else {
             if (control_index.size() == 0) {
                 if (target_index.size() == 1) {
@@ -130,7 +125,9 @@ void QuantumGateDiagonalMatrix::update_quantum_state(QuantumStateBase* state) {
         }
 #endif
     } else {
-        std::cerr << "not implemented" << std::endl;
+        throw NotImplementedException(
+            "QuantumGateDiagonalMatrix::update_quantum_state for density "
+            "matrix is not implemented");
     }
 }
 

--- a/src/cppsim/gate_matrix_diagonal.hpp
+++ b/src/cppsim/gate_matrix_diagonal.hpp
@@ -4,7 +4,7 @@
 #include "type.hpp"
 
 /**
- * \~japanese-en �s��v�f�Ŏ��g����p������e��ێ�����N���X
+ * \~japanese-en 行列要素で自身が作用する内容を保持するクラス
  */
 class DllExport QuantumGateDiagonalMatrix : public QuantumGateBase {
 private:
@@ -13,39 +13,39 @@ private:
 
 public:
     /**
-     * \~japanese-en �R���X�g���N�^
+     * \~japanese-en コンストラクタ
      *
-     * �s��v�f�̓R�s�[����邽�߁Amatrix�͍ė��p�ł��邪�ᑬ�ł���
-     * @param target_qubit_index_list �^�[�Q�b�g�ƂȂ�ʎq�r�b�g�̓Y�����̃��X�g
-     * @param matrix_element �s��v�f
-     * @param control_qubit_index_list �R���g���[���ƂȂ�ʎq�r�b�g�̃��X�g
-     * <code>control_value</code>�͂��ׂ�1�ɂȂ�B
+     * 行列要素はコピーされるため、matrixは再利用できるが低速である
+     * @param target_qubit_index_list ターゲットとなる量子ビットの添え字のリスト
+     * @param matrix_element 行列要素
+     * @param control_qubit_index_list コントロールとなる量子ビットのリスト
+     * <code>control_value</code>はすべて1になる。
      */
     QuantumGateDiagonalMatrix(const std::vector<UINT>& target_qubit_index_list,
         const ComplexVector& matrix_element,
         const std::vector<UINT>& control_qubit_index_list = {});
 
     /**
-     * \~japanese-en �R���X�g���N�^
+     * \~japanese-en コンストラクタ
      *
-     * �s��v�f��swap����邽�߁Amatrix�͍ė��p�ł��Ȃ��������ł���B
-     * @param target_qubit_index_list �^�[�Q�b�g�ƂȂ�ʎq�r�b�g�̓Y�����̃��X�g
-     * @param matrix_element �s��v�f
-     * @param control_qubit_index_list �R���g���[���ƂȂ�ʎq�r�b�g�̃��X�g
-     * <code>control_value</code>�͂��ׂ�1�ɂȂ�B
+     * 行列要素はswapされるため、matrixは再利用できないが高速である。
+     * @param target_qubit_index_list ターゲットとなる量子ビットの添え字のリスト
+     * @param matrix_element 行列要素
+     * @param control_qubit_index_list コントロールとなる量子ビットのリスト
+     * <code>control_value</code>はすべて1になる。
      */
     QuantumGateDiagonalMatrix(const std::vector<UINT>& target_qubit_index_list,
         ComplexVector* matrix_element,
         const std::vector<UINT>& control_qubit_index_list = {});
 
     /**
-     * \~japanese-en �R���X�g���N�^
+     * \~japanese-en コンストラクタ
      *
-     * �s��v�f�̓R�s�[����邽�߁Amatrix�͍ė��p�ł��邪�ᑬ�ł���
-     * @param target_qubit_index_list �^�[�Q�b�g�ƂȂ�ʎq�r�b�g�̏��̃��X�g
-     * @param matrix_element �s��v�f
+     * 行列要素はコピーされるため、matrixは再利用できるが低速である
+     * @param target_qubit_index_list ターゲットとなる量子ビットの情報のリスト
+     * @param matrix_element 行列要素
      * @param control_qubit_index_list
-     * �R���g���[���ƂȂ�ʎq�r�b�g�̏��̃��X�g
+     * コントロールとなる量子ビットの情報のリスト
      */
     QuantumGateDiagonalMatrix(
         const std::vector<TargetQubitInfo>& target_qubit_index_list,
@@ -53,13 +53,13 @@ public:
         const std::vector<ControlQubitInfo>& control_qubit_index_list = {});
 
     /**
-     * \~japanese-en �R���X�g���N�^
+     * \~japanese-en コンストラクタ
      *
-     * �s��v�f��swap����邽�߁Amatrix�͍ė��p�ł��Ȃ��������ł���B
-     * @param target_qubit_index_list �^�[�Q�b�g�ƂȂ�ʎq�r�b�g�̏��̃��X�g
-     * @param matrix_element �s��v�f
+     * 行列要素はswapされるため、matrixは再利用できないが高速である。
+     * @param target_qubit_index_list ターゲットとなる量子ビットの情報のリスト
+     * @param matrix_element 行列要素
      * @param control_qubit_index_list
-     * �R���g���[���ƂȂ�ʎq�r�b�g�̏��̃��X�g
+     * コントロールとなる量子ビットの情報のリスト
      */
     QuantumGateDiagonalMatrix(
         const std::vector<TargetQubitInfo>& target_qubit_index_list,
@@ -72,51 +72,51 @@ public:
     virtual ~QuantumGateDiagonalMatrix(){};
 
     /**
-     * \~japanese-en �R���g���[���̗ʎq�r�b�g��ǉ�����
+     * \~japanese-en コントロールの量子ビットを追加する
      *
-     * <code>qubit_index</code>�̓Q�[�g�̃^�[�Q�b�g��R���g���[���̒l�Ɋ܂܂�Ă͂����Ȃ��B
-     * @param[in] qubit_index �R���g���[���̗ʎq�r�b�g�̓Y����
+     * <code>qubit_index</code>はゲートのターゲットやコントロールの値に含まれてはいけない。
+     * @param[in] qubit_index コントロールの量子ビットの添え字
      * @param[in] control_value
-     * ����<code>qubit_index</code>��<code>control_value</code>�ł���ꍇ�ɂ̂݃Q�[�g����p����B
+     * 基底の<code>qubit_index</code>が<code>control_value</code>である場合にのみゲートが作用する。
      */
     virtual void add_control_qubit(UINT qubit_index, UINT control_value);
 
     /**
-     * \~japanese-en �Q�[�g�s��ɃX�J���[�l��������
+     * \~japanese-en ゲート行列にスカラー値をかける
      *
-     * @param[in] value ������l
+     * @param[in] value かける値
      */
     virtual void multiply_scalar(CPPCTYPE value) { _diagonal_element *= value; }
 
     /**
-     * \~japanese-en �Q�[�g�̃v���p�e�B��ݒ肷��
+     * \~japanese-en ゲートのプロパティを設定する
      *
-     * @param[in] gate_property_ �Q�[�g�̃v���p�e�B�l
+     * @param[in] gate_property_ ゲートのプロパティ値
      */
     virtual void set_gate_property(UINT gate_property_) {
         _gate_property = gate_property_;
     }
 
     /**
-     * \~japanese-en �ʎq��Ԃɍ�p����
+     * \~japanese-en 量子状態に作用する
      *
-     * @param[in,out] state �X�V����ʎq���
+     * @param[in,out] state 更新する量子状態
      */
     virtual void update_quantum_state(QuantumStateBase* state) override;
 
     /**
-     * \~japanese-en ���g�̃R�s�[���쐬����
+     * \~japanese-en 自身のコピーを作成する
      *
-     * @return �R�s�[���ꂽ�Q�[�g�̃C���X�^���X
+     * @return コピーされたゲートのインスタンス
      */
     virtual QuantumGateBase* copy() const override {
         return new QuantumGateDiagonalMatrix(*this);
     };
 
     /**
-     * \~japanese-en ���g�̍s��v�f���Z�b�g����
+     * \~japanese-en 自身の行列要素をセットする
      *
-     * @param[out] matrix �s��v�f���Z�b�g����s��̎Q��
+     * @param[out] matrix 行列要素をセットする行列の参照
      */
     virtual void set_matrix(ComplexMatrix& matrix) const override {
         ITYPE dim = this->_diagonal_element.size();
@@ -127,29 +127,28 @@ public:
     }
 
     /**
-     * \~japanese-en
-     * �ʎq��H�̃f�o�b�O���̕�����𐶐�����
+     * \~japanese-en 量子回路のデバッグ情報の文字列を生成する
      *
-     * @return ��������������
+     * @return 生成した文字列
      */
     virtual std::string to_string() const override;
 
     /**
-     * \~japanese-en �Q�[�g�̏��𕶎���ŏo�͂���
+     * \~japanese-en ゲートの情報を文字列で出力する
      *
-     * @param os �o�͂���X�g���[��
-     * @param gate ���̏o�͂��s���Q�[�g
-     * @return �󂯎�����X�g���[��
+     * @param os 出力するストリーム
+     * @param gate 情報の出力を行うゲート
+     * @return 受け取ったストリーム
      */
     friend DllExport std::ostream& operator<<(
         std::ostream& os, const QuantumGateDiagonalMatrix& gate);
 
     /**
-     * \~japanese-en �Q�[�g�̏��𕶎���ŏo�͂���
+     * \~japanese-en ゲートの情報を文字列で出力する
      *
-     * @param os �o�͂���X�g���[��
-     * @param gate ���̏o�͂��s���Q�[�g
-     * @return �󂯎�����X�g���[��
+     * @param os 出力するストリーム
+     * @param gate 情報の出力を行うゲート
+     * @return 受け取ったストリーム
      */
     friend DllExport std::ostream& operator<<(
         std::ostream& os, QuantumGateDiagonalMatrix* gate);

--- a/src/cppsim/gate_matrix_diagonal.hpp
+++ b/src/cppsim/gate_matrix_diagonal.hpp
@@ -5,6 +5,7 @@
 
 /**
  * \~japanese-en 行列要素で自身が作用する内容を保持するクラス
+ * 対角行列を持つ。
  */
 class DllExport QuantumGateDiagonalMatrix : public QuantumGateBase {
 private:

--- a/src/cppsim/gate_matrix_sparse.cpp
+++ b/src/cppsim/gate_matrix_sparse.cpp
@@ -71,7 +71,7 @@ void QuantumGateSparseMatrix::update_quantum_state(QuantumStateBase* state) {
     ITYPE dim = 1ULL << state->qubit_count;
 
     if (this->_control_qubit_list.size() > 0) {
-        throw InvalidControlQubitException(
+        throw NotImplementedException(
             "Control qubit in sparse matrix gate is not supported");
     }
 
@@ -96,7 +96,9 @@ void QuantumGateSparseMatrix::update_quantum_state(QuantumStateBase* state) {
             dim);
 #endif
     } else {
-        throw NotImplementedException("not implemented");
+        throw NotImplementedException(
+            "QuantumGateSparseMatrix::update_quantum_state for density "
+            "matrix is not implemented");
     }
 }
 

--- a/src/cppsim/gate_matrix_sparse.hpp
+++ b/src/cppsim/gate_matrix_sparse.hpp
@@ -4,7 +4,7 @@
 #include "type.hpp"
 
 /**
- * \~japanese-en �s��v�f�Ŏ��g����p������e��ێ�����N���X
+ * \~japanese-en 行列要素で自身が作用する内容を保持するクラス
  */
 class DllExport QuantumGateSparseMatrix : public QuantumGateBase {
 private:
@@ -14,39 +14,39 @@ private:
 
 public:
     /**
-     * \~japanese-en �R���X�g���N�^
+     * \~japanese-en コンストラクタ
      *
-     * �s��v�f�̓R�s�[����邽�߁Amatrix�͍ė��p�ł��邪�ᑬ�ł���
-     * @param target_qubit_index_list �^�[�Q�b�g�ƂȂ�ʎq�r�b�g�̓Y�����̃��X�g
-     * @param matrix_element �s��v�f
-     * @param control_qubit_index_list �R���g���[���ƂȂ�ʎq�r�b�g�̃��X�g
-     * <code>control_value</code>�͂��ׂ�1�ɂȂ�B
+     * 行列要素はコピーされるため、matrixは再利用できるが低速である
+     * @param target_qubit_index_list ターゲットとなる量子ビットの添え字のリスト
+     * @param matrix_element 行列要素
+     * @param control_qubit_index_list コントロールとなる量子ビットのリスト
+     * <code>control_value</code>はすべて1になる。
      */
     QuantumGateSparseMatrix(const std::vector<UINT>& target_qubit_index_list,
         const SparseComplexMatrix& matrix_element,
         const std::vector<UINT>& control_qubit_index_list = {});
 
     /**
-     * \~japanese-en �R���X�g���N�^
+     * \~japanese-en コンストラクタ
      *
-     * �s��v�f��swap����邽�߁Amatrix�͍ė��p�ł��Ȃ��������ł���B
-     * @param target_qubit_index_list �^�[�Q�b�g�ƂȂ�ʎq�r�b�g�̓Y�����̃��X�g
-     * @param matrix_element �s��v�f
-     * @param control_qubit_index_list �R���g���[���ƂȂ�ʎq�r�b�g�̃��X�g
-     * <code>control_value</code>�͂��ׂ�1�ɂȂ�B
+     * 行列要素はswapされるため、matrixは再利用できないが高速である。
+     * @param target_qubit_index_list ターゲットとなる量子ビットの添え字のリスト
+     * @param matrix_element 行列要素
+     * @param control_qubit_index_list コントロールとなる量子ビットのリスト
+     * <code>control_value</code>はすべて1になる。
      */
     QuantumGateSparseMatrix(const std::vector<UINT>& target_qubit_index_list,
         SparseComplexMatrix* matrix_element,
         const std::vector<UINT>& control_qubit_index_list = {});
 
     /**
-     * \~japanese-en �R���X�g���N�^
+     * \~japanese-en コンストラクタ
      *
-     * �s��v�f�̓R�s�[����邽�߁Amatrix�͍ė��p�ł��邪�ᑬ�ł���
-     * @param target_qubit_index_list �^�[�Q�b�g�ƂȂ�ʎq�r�b�g�̏��̃��X�g
-     * @param matrix_element �s��v�f
+     * 行列要素はコピーされるため、matrixは再利用できるが低速である
+     * @param target_qubit_index_list ターゲットとなる量子ビットの情報のリスト
+     * @param matrix_element 行列要素
      * @param control_qubit_index_list
-     * �R���g���[���ƂȂ�ʎq�r�b�g�̏��̃��X�g
+     * コントロールとなる量子ビットの情報のリスト
      */
     QuantumGateSparseMatrix(
         const std::vector<TargetQubitInfo>& target_qubit_index_list,
@@ -54,13 +54,13 @@ public:
         const std::vector<ControlQubitInfo>& control_qubit_index_list = {});
 
     /**
-     * \~japanese-en �R���X�g���N�^
+     * \~japanese-en コンストラクタ
      *
-     * �s��v�f��swap����邽�߁Amatrix�͍ė��p�ł��Ȃ��������ł���B
-     * @param target_qubit_index_list �^�[�Q�b�g�ƂȂ�ʎq�r�b�g�̏��̃��X�g
-     * @param matrix_element �s��v�f
+     * 行列要素はswapされるため、matrixは再利用できないが高速である。
+     * @param target_qubit_index_list ターゲットとなる量子ビットの情報のリスト
+     * @param matrix_element 行列要素
      * @param control_qubit_index_list
-     * �R���g���[���ƂȂ�ʎq�r�b�g�̏��̃��X�g
+     * コントロールとなる量子ビットの情報のリスト
      */
     QuantumGateSparseMatrix(
         const std::vector<TargetQubitInfo>& target_qubit_index_list,
@@ -68,85 +68,84 @@ public:
         const std::vector<ControlQubitInfo>& control_qubit_index_list = {});
 
     /**
-     * \~japanese-en �f�X�g���N�^
+     * \~japanese-en デストラクタ
      */
     virtual ~QuantumGateSparseMatrix(){};
 
     /**
-     * \~japanese-en �R���g���[���̗ʎq�r�b�g��ǉ�����
+     * \~japanese-en コントロールの量子ビットを追加する
      *
-     * <code>qubit_index</code>�̓Q�[�g�̃^�[�Q�b�g��R���g���[���̒l�Ɋ܂܂�Ă͂����Ȃ��B
-     * @param[in] qubit_index �R���g���[���̗ʎq�r�b�g�̓Y����
+     * <code>qubit_index</code>はゲートのターゲットやコントロールの値に含まれてはいけない。
+     * @param[in] qubit_index コントロールの量子ビットの添え字
      * @param[in] control_value
-     * ����<code>qubit_index</code>��<code>control_value</code>�ł���ꍇ�ɂ̂݃Q�[�g����p����B
+     * 基底の<code>qubit_index</code>が<code>control_value</code>である場合にのみゲートが作用する。
      */
     virtual void add_control_qubit(UINT qubit_index, UINT control_value);
 
     /**
-     * \~japanese-en �Q�[�g�s��ɃX�J���[�l��������
+     * \~japanese-en ゲート行列にスカラー値をかける
      *
-     * @param[in] value ������l
+     * @param[in] value かける値
      */
     virtual void multiply_scalar(CPPCTYPE value) { _matrix_element *= value; }
 
     /**
-     * \~japanese-en �Q�[�g�̃v���p�e�B��ݒ肷��
+     * \~japanese-en ゲートのプロパティを設定する
      *
-     * @param[in] gate_property_ �Q�[�g�̃v���p�e�B�l
+     * @param[in] gate_property_ ゲートのプロパティ値
      */
     virtual void set_gate_property(UINT gate_property_) {
         _gate_property = gate_property_;
     }
 
     /**
-     * \~japanese-en �ʎq��Ԃɍ�p����
+     * \~japanese-en 量子状態に作用する
      *
-     * @param[in,out] state �X�V����ʎq���
+     * @param[in,out] state 更新する量子状態
      */
     virtual void update_quantum_state(QuantumStateBase* state) override;
 
-    /**
-     * \~japanese-en ���g�̃R�s�[���쐬����
+     /**
+     * \~japanese-en 自身のコピーを作成する
      *
-     * @return �R�s�[���ꂽ�Q�[�g�̃C���X�^���X
+     * @return コピーされたゲートのインスタンス
      */
     virtual QuantumGateBase* copy() const override {
         return new QuantumGateSparseMatrix(*this);
     };
 
     /**
-     * \~japanese-en ���g�̍s��v�f���Z�b�g����
+     * \~japanese-en 自身の行列要素をセットする
      *
-     * @param[out] matrix �s��v�f���Z�b�g����s��̎Q��
+     * @param[out] matrix 行列要素をセットする行列の参照
      */
     virtual void set_matrix(ComplexMatrix& matrix) const override {
         matrix = this->_matrix_element.toDense();
     }
 
     /**
-     * \~japanese-en
-     * �ʎq��H�̃f�o�b�O���̕�����𐶐�����
+     * \~japanese-en 量子回路のデバッグ情報の文字列を生成する
      *
-     * @return ��������������
+     * @return 生成した文字列
      */
     virtual std::string to_string() const override;
 
     /**
-     * \~japanese-en �Q�[�g�̏��𕶎���ŏo�͂���
+     * \~japanese-en ゲートの情報を文字列で出力する
      *
-     * @param os �o�͂���X�g���[��
-     * @param gate ���̏o�͂��s���Q�[�g
-     * @return �󂯎�����X�g���[��
+     * @param os 出力するストリーム
+     * @param gate 情報の出力を行うゲート
+     * @return 受け取ったストリーム
      */
     friend DllExport std::ostream& operator<<(
         std::ostream& os, const QuantumGateSparseMatrix& gate);
 
     /**
-     * \~japanese-en �Q�[�g�̏��𕶎���ŏo�͂���
+     * \~japanese-en ゲートの情報を文字列で出力する
      *
-     * @param os �o�͂���X�g���[��
-     * @param gate ���̏o�͂��s���Q�[�g
-     * @return �󂯎�����X�g���[��
+     * @param os 出力するストリーム
+     * @param gate 情報の出力を行うゲート
+     * @return 受け取ったストリーム
      */
     friend DllExport std::ostream& operator<<(
         std::ostream& os, QuantumGateSparseMatrix* gate);

--- a/src/cppsim/gate_matrix_sparse.hpp
+++ b/src/cppsim/gate_matrix_sparse.hpp
@@ -105,7 +105,7 @@ public:
      */
     virtual void update_quantum_state(QuantumStateBase* state) override;
 
-     /**
+    /**
      * \~japanese-en 自身のコピーを作成する
      *
      * @return コピーされたゲートのインスタンス

--- a/src/cppsim/gate_matrix_sparse.hpp
+++ b/src/cppsim/gate_matrix_sparse.hpp
@@ -5,6 +5,7 @@
 
 /**
  * \~japanese-en 行列要素で自身が作用する内容を保持するクラス
+ * 疎行列を持つ。
  */
 class DllExport QuantumGateSparseMatrix : public QuantumGateBase {
 private:

--- a/src/cppsim/gate_reflect.hpp
+++ b/src/cppsim/gate_reflect.hpp
@@ -15,7 +15,7 @@
 
 /**
  * \~japanese-en
- * �ʎq��Ԃ��A�ʂ̗ʎq��Ԃɑ΂��Ĕ��˂���Q�[�g�̃N���X
+ * 量子状態を、別の量子状態に対して反射するゲートのクラス
  */
 class ClsStateReflectionGate : public QuantumGateBase {
 private:
@@ -33,9 +33,9 @@ public:
     virtual ~ClsStateReflectionGate() { delete reflection_state; }
 
     /**
-     * \~japanese-en �ʎq��Ԃ��X�V����
+     * \~japanese-en 量子状態を更新する
      *
-     * @param state �X�V����ʎq���
+     * @param state 更新する量子状態
      */
     virtual void update_quantum_state(QuantumStateBase* state) override {
         if (state->is_state_vector()) {
@@ -67,17 +67,17 @@ public:
     };
     /**
      * \~japanese-en
-     * ���g�̃f�B�[�v�R�s�[�𐶐�����
+     * 自身のディープコピーを生成する
      *
-     * @return ���g�̃f�B�[�v�R�s�[
+     * @return 自身のディープコピー
      */
     virtual QuantumGateBase* copy() const override {
         return new ClsStateReflectionGate(this->reflection_state);
     };
     /**
-     * \~japanese-en ���g�̃Q�[�g�s����Z�b�g����
+     * \~japanese-en 自身のゲート行列をセットする
      *
-     * @param matrix �s����Z�b�g����ϐ��̎Q��
+     * @param matrix 行列をセットする変数の参照
      */
     virtual void set_matrix(ComplexMatrix&) const override {
         throw NotImplementedException(

--- a/src/cppsim/gate_reflect.hpp
+++ b/src/cppsim/gate_reflect.hpp
@@ -75,7 +75,8 @@ public:
         return new ClsStateReflectionGate(this->reflection_state);
     };
     /**
-     * \~japanese-en 自身のゲート行列をセットする
+     * \~japanese-en 自身のゲート行列をセットする ことになっているが、実際はnot
+     * implemented
      *
      * @param matrix 行列をセットする変数の参照
      */

--- a/src/cppsim/gate_reversible.hpp
+++ b/src/cppsim/gate_reversible.hpp
@@ -14,7 +14,7 @@
 #include <iostream>
 
 /**
- * \~japanese-en �t�ÓT��H�̂�\���N���X
+ * \~japanese-en 可逆古典回路のを表すクラス
  */
 class ClsReversibleBooleanGate : public QuantumGateBase {
 private:
@@ -31,9 +31,9 @@ public:
     };
 
     /**
-     * \~japanese-en �ʎq��Ԃ��X�V����
+     * \~japanese-en 量子状態を更新する
      *
-     * @param state �X�V����ʎq���
+     * @param state 更新する量子状態
      */
     virtual void update_quantum_state(QuantumStateBase* state) override {
         std::vector<UINT> target_index;
@@ -63,17 +63,17 @@ public:
     };
     /**
      * \~japanese-en
-     * ���g�̃f�B�[�v�R�s�[�𐶐�����
+     * 自身のディープコピーを生成する
      *
-     * @return ���g�̃f�B�[�v�R�s�[
+     * @return 自身のディープコピー
      */
     virtual QuantumGateBase* copy() const override {
         return new ClsReversibleBooleanGate(*this);
     };
     /**
-     * \~japanese-en ���g�̃Q�[�g�s����Z�b�g����
+     * \~japanese-en 自身のゲート行列をセットする
      *
-     * @param matrix �s����Z�b�g����ϐ��̎Q��
+     * @param matrix 行列をセットする変数の参照
      */
     virtual void set_matrix(ComplexMatrix& matrix) const override {
         ITYPE matrix_dim = 1ULL << this->_target_qubit_list.size();

--- a/src/cppsim/observable.cpp
+++ b/src/cppsim/observable.cpp
@@ -54,7 +54,8 @@ HermitianQuantumOperator::solve_ground_state_eigenvalue_by_lanczos_method(
     }
 
     // Implemented based on
-    // https://files.transtutors.com/cdn/uploadassignments/472339_1_-numerical-linear-aljebra.pdf
+    // https://en.wikipedia.org/wiki/Lanczos_algorithm
+    // https://math.berkeley.edu/~mgu/MA128BSpring2018/Lanczos.pdf
     CPPCTYPE mu_;
     if (mu == 0.0) {
         // mu is not changed from default value.

--- a/src/cppsim/pauli_operator.cpp
+++ b/src/cppsim/pauli_operator.cpp
@@ -52,6 +52,7 @@ PauliOperator::PauliOperator(const std::vector<UINT>& target_qubit_list,
     std::string Pauli_operator_type_list, CPPCTYPE coef)
     : _coef(coef) {
     UINT term_count = (UINT)(strlen(Pauli_operator_type_list.c_str()));
+    assert((UINT)target_qubit_list.size() == term_count);
     UINT pauli_type = 0;
     for (UINT term_index = 0; term_index < term_count; ++term_index) {
         if (Pauli_operator_type_list[term_index] == 'i' ||
@@ -253,7 +254,7 @@ std::string PauliOperator::get_pauli_string() const {
     UINT size = _pauli_list.size();
     UINT target_index, pauli_id;
     if (size == 0) {
-        return "I";
+        return "";
     }
     for (UINT index = 0; index < size; index++) {
         target_index = _pauli_list[index].index();

--- a/src/cppsim/qubit_info.hpp
+++ b/src/cppsim/qubit_info.hpp
@@ -95,7 +95,7 @@ public:
  */
 class DllExport TargetQubitInfo : public QubitInfo {
 private:
-    // \~japanese-en この量子ビットがパウリ演算子と可換か同課を保持する値
+    // \~japanese-en この量子ビットがパウリ演算子と可換かどうかを保持する値
     UINT _commutation_property;
 
 public:

--- a/src/cppsim/state_dm.hpp
+++ b/src/cppsim/state_dm.hpp
@@ -365,8 +365,8 @@ public:
     virtual void multiply_elementwise_function(
         const std::function<CPPCTYPE(ITYPE)>&) override {
         throw NotImplementedException(
-            "multiply_elementwise_function between density matrix and "
-            "state vector is not implemented");
+            "multiply_elementwise_function for density matrix is not "
+            "implemented");
     }
 
     /**

--- a/src/cppsim/utility.cpp
+++ b/src/cppsim/utility.cpp
@@ -128,14 +128,15 @@ std::tuple<double, double, std::string> parse_openfermion_line(
     return std::make_tuple(coef_real, coef_imag, str_buf);
 }
 
-bool check_is_unique_index_list(std::vector<UINT> index_list) {
-    sort(index_list.begin(), index_list.end());
-    bool flag = true;
-    for (UINT i = 0; i + 1 < index_list.size(); ++i) {
-        flag = flag & (index_list[i] != index_list[i + 1]);
-        if (!flag) break;
+bool check_is_unique_index_list(const std::vector<UINT>& index_list) {
+    std::vector<UINT> index_list_sorted(index_list.begin(), index_list.end());
+    sort(index_list_sorted.begin(), index_list_sorted.end());
+    bool is_unique = true;
+    for (UINT i = 0; i + 1 < index_list_sorted.size(); ++i) {
+        is_unique &= (index_list_sorted[i] != index_list_sorted[i + 1]);
+        if (!is_unique) break;
     }
-    return flag;
+    return is_unique;
 }
 
 std::string& rtrim(std::string& str) {

--- a/src/cppsim/utility.hpp
+++ b/src/cppsim/utility.hpp
@@ -212,7 +212,7 @@ DllExport std::tuple<double, double, std::string> parse_openfermion_line(
  * @param[in] index_list チェックする配列
  * @return 重複がある場合にtrue、ない場合にfalse
  */
-bool check_is_unique_index_list(std::vector<UINT> index_list);
+bool check_is_unique_index_list(const std::vector<UINT>& index_list);
 
 /**
  * \~japanese-en 与えられた文字列の末尾の空白文字を削除します。

--- a/test/cppsim/test_noisyevolution.cpp
+++ b/test/cppsim/test_noisyevolution.cpp
@@ -139,7 +139,7 @@ TEST(NoisyEvolutionTest, EffectiveHamiltonian) {
     auto gate = dynamic_cast<ClsNoisyEvolution*>(
         gate::NoisyEvolution(&hamiltonian, c_ops, time, dt));
     ASSERT_EQ(gate->get_effective_hamiltonian()->to_string(),
-        "(1,0) Z 0 Z 1 + (0,-1) I");
+        "(1,0) Z 0 Z 1 + (0,-1) ");
 }
 
 TEST(NoisyEvolutionTest, dephasing) {

--- a/test/cppsim/test_pauli_operator.cpp
+++ b/test/cppsim/test_pauli_operator.cpp
@@ -11,6 +11,13 @@ TEST(PauliOperatorTest, ContainsExtraWhitespace) {
     EXPECT_EQ(expected.get_pauli_string(), pauli_whitespace.get_pauli_string());
 }
 
+TEST(PauliOperatorTest, EmptyStringConstructsIdentity) {
+    const auto identity = PauliOperator("", 1.0);
+    ASSERT_EQ(0, identity.get_index_list().size());
+    ASSERT_EQ(0, identity.get_pauli_id_list().size());
+    ASSERT_EQ("", identity.get_pauli_string());
+}
+
 struct PauliTestParam {
     std::string test_name;
     PauliOperator op1;


### PR DESCRIPTION
#247
読めないコメントを、http://docs.qulacs.org/ja/latest/index.html　とか、元がgate_matrixからのコピペだったりするものがあったので、補いました。
ついでに　merge_circuit　で二つの回路のqubitが違っていても、定義上何の問題もないはずなので、エラー吐かないようにしました