### PR TITLE
Release v0.3.0 -> v0.3.1

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -14,7 +14,7 @@ ENV PYENV_ROOT="/.pyenv"
 ENV PATH="${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"
 ENV PWD="/workspaces/qulacs-osaka"
 ENV QULACS_OSAKA_PACKAGE="qulacs_osaka"
-ENV QULACS_OSAKA_VERSION="0.3.0"
+ENV QULACS_OSAKA_VERSION="0.3.1"
 # Add build artifact to PYTHONPATH and python can find qulacs.
 # Egg file name might vary depending on qulacs and python version.
 ENV PYTHONPATH="${PWD}/dist/${QULACS_OSAKA_PACKAGE}-${QULACS_OSAKA_VERSION}-cp39-cp39-linux_x86_64.whl:${PYTHONPATH}"

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import sys
 from setuptools import Extension, find_packages, setup
 from setuptools.command.build_ext import build_ext
 
-VERSION = "0.3.0"
+VERSION = "0.3.1"
 PROJECT_NAME = "qulacs-osaka"
 
 


### PR DESCRIPTION
このプルリクでは、qulacs-osakaの新バージョンv0.3.1をリリースするための準備をします。

### 確認してほしい内容
- リリース時期が適切かどうか
- バージョン番号が適切かどうか

参考: https://github.com/Qulacs-Osaka/qulacs-developer-docs/blob/main/doc/Decisions/release-cycle.md

前回: https://github.com/Qulacs-Osaka/qulacs-osaka/pull/285

0.3.0からの変更点は
- 乱数関係のメソッドにシードを指定できるようになった (#291)
- stubの重複コメントをどけた (#293,#300)
- QuantumGateにget_control_index_list(),get_control_value_list()が追加された (#297)
- cppsimの軽微なリファクタリングをいくつか(KowerKoint) (#301,#305)
- 一部gateのnameが設定されてなかったので設定した (#303)

になります(開発環境の仕様変更を除く)。