### PR TITLE
update StateTest(SetHaarRandomState, Sampling, GetZeroProbability)

### DIFF
--- a/test/cppsim/test_state.cpp
+++ b/test/cppsim/test_state.cpp
@@ -50,21 +50,21 @@ TEST(StateTest, SamplingSuperpositionState) {
     const UINT n = 10;
     const UINT nshot = 1024;
     QuantumState state(n);
-    state.set_computational_basis(1);
-    for (ITYPE i = 2; i <= 5; ++i) {
+    state.set_computational_basis(0);
+    for (ITYPE i = 1; i <= 4; ++i) {
         QuantumState tmp_state(n);
         tmp_state.set_computational_basis(i);
         state.add_state_with_coef_single_thread(1 << i, &tmp_state);
     }
     state.normalize_single_thread(state.get_squared_norm_single_thread());
     auto res = state.sampling(nshot);
-    std::array<UINT, 6> cnt = {};
+    std::array<UINT, 5> cnt = {};
     for (UINT i = 0; i < nshot; ++i) {
-        ASSERT_GE(res[i], 1);
-        ASSERT_LE(res[i], 5);
+        ASSERT_GE(res[i], 0);
+        ASSERT_LE(res[i], 4);
         cnt[res[i]] += 1;
     }
-    for (UINT i = 1; i < 5; i++) {
+    for (UINT i = 0; i < 4; i++) {
         ASSERT_GT(cnt[i + 1], cnt[i]);
     }
 }

--- a/test/cppsim/test_state.cpp
+++ b/test/cppsim/test_state.cpp
@@ -52,24 +52,20 @@ TEST(StateTest, Sampling) {
         const UINT nshot = 1024;
         QuantumState state(n);
         state.set_computational_basis(1);
-        for (ITYPE i = 2; i <= 10; ++i) {
+        for (ITYPE i = 2; i <= 5; ++i) {
             QuantumState tmp_state(n);
             tmp_state.set_computational_basis(i);
-            state.add_state_with_coef_single_thread(std::sqrt(i), &tmp_state);
+            state.add_state_with_coef_single_thread(1 << i, &tmp_state);
         }
         state.normalize_single_thread(state.get_squared_norm_single_thread());
         auto res = state.sampling(nshot);
-        std::array<UINT, 11> cnt = {};
+        std::array<UINT, 6> cnt = {};
         for (UINT i = 0; i < nshot; ++i) {
             ASSERT_GE(res[i], 1);
-            ASSERT_LE(res[i], 10);
+            ASSERT_LE(res[i], 5);
             cnt[res[i]] += 1;
         }
-        for (UINT i = 1; i <= 10; i++) {
-            std::cerr << ' ' << cnt[i];
-        }
-        std::cerr << std::endl;
-        for (UINT i = 1; i < 10; i++) {
+        for (UINT i = 1; i < 5; i++) {
             ASSERT_GT(cnt[i + 1], cnt[i]);
         }
     }

--- a/test/cppsim/test_state.cpp
+++ b/test/cppsim/test_state.cpp
@@ -133,36 +133,34 @@ TEST(StateTest, StateTest_HaarRandomStateSameSeed) {
 }
 
 TEST(StateTest, GetZeroProbability) {
-    {
-        const UINT n = 10;
-        const double eps = 1e-10;
-        QuantumState state(n);
-        state.set_computational_basis(1);
-        for (ITYPE i = 2; i <= 10; ++i) {
-            QuantumState tmp_state(n);
-            tmp_state.set_computational_basis(i);
-            state.add_state_with_coef_single_thread(std::sqrt(i), &tmp_state);
-        }
-        state.normalize_single_thread(state.get_squared_norm_single_thread());
-        ASSERT_NEAR(state.get_zero_probability(0), 30.0 / 55.0, eps);
-        ASSERT_NEAR(state.get_zero_probability(1), 27.0 / 55.0, eps);
-        ASSERT_NEAR(state.get_zero_probability(2), 33.0 / 55.0, eps);
-        ASSERT_NEAR(state.get_zero_probability(3), 28.0 / 55.0, eps);
-
-        std::vector<UINT> measured_values(n, 2);
-        measured_values[0] = measured_values[1] = 0;
-        ASSERT_NEAR(
-            state.get_marginal_probability(measured_values), 12.0 / 55.0, eps);
-        measured_values[0] = 1;
-        ASSERT_NEAR(
-            state.get_marginal_probability(measured_values), 15.0 / 55.0, eps);
-        measured_values[1] = 1;
-        ASSERT_NEAR(
-            state.get_marginal_probability(measured_values), 10.0 / 55.0, eps);
-        measured_values[0] = 0;
-        ASSERT_NEAR(
-            state.get_marginal_probability(measured_values), 18.0 / 55.0, eps);
+    const UINT n = 10;
+    const double eps = 1e-10;
+    QuantumState state(n);
+    state.set_computational_basis(1);
+    for (ITYPE i = 2; i <= 10; ++i) {
+        QuantumState tmp_state(n);
+        tmp_state.set_computational_basis(i);
+        state.add_state_with_coef_single_thread(std::sqrt(i), &tmp_state);
     }
+    state.normalize_single_thread(state.get_squared_norm_single_thread());
+    ASSERT_NEAR(state.get_zero_probability(0), 30.0 / 55.0, eps);
+    ASSERT_NEAR(state.get_zero_probability(1), 27.0 / 55.0, eps);
+    ASSERT_NEAR(state.get_zero_probability(2), 33.0 / 55.0, eps);
+    ASSERT_NEAR(state.get_zero_probability(3), 28.0 / 55.0, eps);
+
+    std::vector<UINT> measured_values(n, 2);
+    measured_values[0] = measured_values[1] = 0;
+    ASSERT_NEAR(
+        state.get_marginal_probability(measured_values), 12.0 / 55.0, eps);
+    measured_values[0] = 1;
+    ASSERT_NEAR(
+        state.get_marginal_probability(measured_values), 15.0 / 55.0, eps);
+    measured_values[1] = 1;
+    ASSERT_NEAR(
+        state.get_marginal_probability(measured_values), 10.0 / 55.0, eps);
+    measured_values[0] = 0;
+    ASSERT_NEAR(
+        state.get_marginal_probability(measured_values), 18.0 / 55.0, eps);
 }
 
 TEST(StateTest, GetMarginalProbability) {

--- a/test/cppsim/test_state.cpp
+++ b/test/cppsim/test_state.cpp
@@ -147,20 +147,6 @@ TEST(StateTest, GetZeroProbability) {
     ASSERT_NEAR(state.get_zero_probability(1), 27.0 / 55.0, eps);
     ASSERT_NEAR(state.get_zero_probability(2), 33.0 / 55.0, eps);
     ASSERT_NEAR(state.get_zero_probability(3), 28.0 / 55.0, eps);
-
-    std::vector<UINT> measured_values(n, 2);
-    measured_values[0] = measured_values[1] = 0;
-    ASSERT_NEAR(
-        state.get_marginal_probability(measured_values), 12.0 / 55.0, eps);
-    measured_values[0] = 1;
-    ASSERT_NEAR(
-        state.get_marginal_probability(measured_values), 15.0 / 55.0, eps);
-    measured_values[1] = 1;
-    ASSERT_NEAR(
-        state.get_marginal_probability(measured_values), 10.0 / 55.0, eps);
-    measured_values[0] = 0;
-    ASSERT_NEAR(
-        state.get_marginal_probability(measured_values), 18.0 / 55.0, eps);
 }
 
 TEST(StateTest, GetMarginalProbability) {

--- a/test/cppsim/test_state.cpp
+++ b/test/cppsim/test_state.cpp
@@ -86,39 +86,49 @@ TEST(StateTest, SetState) {
     }
 }
 
-TEST(StateTest, SetHaarRandomState) {
-    auto same_state = [](QuantumState* s1, QuantumState* s2) -> bool {
-        const double eps = 1e-10;
-        assert(s1->qubit_count == s2->qubit_count);
-        auto s1_data = s1->data_cpp();
-        auto s2_data = s2->data_cpp();
-        for (ITYPE i = 0; i < s1->dim; ++i) {
-            if (abs(s1_data[i] - s2_data[i]) > eps) return false;
-        }
-        return true;
-    };
-    {
-        const UINT n = 10, m = 5;
-        std::vector<QuantumState*> states(m);
-        for (UINT i = 0; i < m; ++i) {
-            states[i] = new QuantumState(n);
-            states[i]->set_Haar_random_state();
-            ASSERT_NEAR(states[i]->get_squared_norm_single_thread(), 1., 1e-10);
-        }
-        for (UINT i = 0; i < m - 1; ++i) {
-            for (UINT j = i + 1; j < m; ++j) {
-                ASSERT_FALSE(same_state(states[i], states[j]));
-            }
+TEST(StateTest, HaarRandomStateNorm) {
+    const UINT n_max = 5, m = 10;
+    for (UINT n = 1; n <= n_max; n++) {
+        for (UINT i = 0; i < m; i++) {
+            QuantumState state(n);
+            state.set_Haar_random_state();
+            ASSERT_NEAR(state.get_squared_norm_single_thread(), 1., 1e-10);
         }
     }
-    {
-        const UINT n = 10, m = 5;
-        for (UINT i = 0; i < m; ++i) {
-            QuantumState state1(n), state2(n);
-            state1.set_Haar_random_state(i);
-            state2.set_Haar_random_state(i);
-            ASSERT_TRUE(same_state(&state1, &state2));
+}
+
+bool same_state(QuantumState* s1, QuantumState* s2) {
+    const double eps = 1e-10;
+    assert(s1->qubit_count == s2->qubit_count);
+    auto s1_data = s1->data_cpp();
+    auto s2_data = s2->data_cpp();
+    for (ITYPE i = 0; i < s1->dim; ++i) {
+        if (abs(s1_data[i] - s2_data[i]) > eps) return false;
+    }
+    return true;
+};
+
+TEST(StateTest, HaarRandomStateWithoutSeed) {
+    const UINT n = 10, m = 5;
+    std::vector<QuantumState*> states(m);
+    for (UINT i = 0; i < m; ++i) {
+        states[i] = new QuantumState(n);
+        states[i]->set_Haar_random_state();
+    }
+    for (UINT i = 0; i < m - 1; ++i) {
+        for (UINT j = i + 1; j < m; ++j) {
+            ASSERT_FALSE(same_state(states[i], states[j]));
         }
+    }
+}
+
+TEST(StateTest, StateTest_HaarRandomStateSameSeed) {
+    const UINT n = 10, m = 5;
+    for (UINT i = 0; i < m; ++i) {
+        QuantumState state1(n), state2(n);
+        state1.set_Haar_random_state(i);
+        state2.set_Haar_random_state(i);
+        ASSERT_TRUE(same_state(&state1, &state2));
     }
 }
 

--- a/test/cppsim/test_state.cpp
+++ b/test/cppsim/test_state.cpp
@@ -35,39 +35,37 @@ TEST(StateTest, GenerateAndRelease) {
     }
 }
 
-TEST(StateTest, Sampling) {
-    {
-        const UINT n = 10;
-        const UINT nshot = 1024;
-        QuantumState state(n);
-        state.set_Haar_random_state();
-        state.set_computational_basis(100);
-        auto res = state.sampling(nshot);
-        for (UINT i = 0; i < nshot; ++i) {
-            ASSERT_TRUE(res[i] == 100);
-        }
+TEST(StateTest, SamplingComputationalBasis) {
+    const UINT n = 10;
+    const UINT nshot = 1024;
+    QuantumState state(n);
+    state.set_computational_basis(100);
+    auto res = state.sampling(nshot);
+    for (UINT i = 0; i < nshot; ++i) {
+        ASSERT_TRUE(res[i] == 100);
     }
-    {
-        const UINT n = 10;
-        const UINT nshot = 1024;
-        QuantumState state(n);
-        state.set_computational_basis(1);
-        for (ITYPE i = 2; i <= 5; ++i) {
-            QuantumState tmp_state(n);
-            tmp_state.set_computational_basis(i);
-            state.add_state_with_coef_single_thread(1 << i, &tmp_state);
-        }
-        state.normalize_single_thread(state.get_squared_norm_single_thread());
-        auto res = state.sampling(nshot);
-        std::array<UINT, 6> cnt = {};
-        for (UINT i = 0; i < nshot; ++i) {
-            ASSERT_GE(res[i], 1);
-            ASSERT_LE(res[i], 5);
-            cnt[res[i]] += 1;
-        }
-        for (UINT i = 1; i < 5; i++) {
-            ASSERT_GT(cnt[i + 1], cnt[i]);
-        }
+}
+
+TEST(StateTest, SamplingSuperpositionState) {
+    const UINT n = 10;
+    const UINT nshot = 1024;
+    QuantumState state(n);
+    state.set_computational_basis(1);
+    for (ITYPE i = 2; i <= 5; ++i) {
+        QuantumState tmp_state(n);
+        tmp_state.set_computational_basis(i);
+        state.add_state_with_coef_single_thread(1 << i, &tmp_state);
+    }
+    state.normalize_single_thread(state.get_squared_norm_single_thread());
+    auto res = state.sampling(nshot);
+    std::array<UINT, 6> cnt = {};
+    for (UINT i = 0; i < nshot; ++i) {
+        ASSERT_GE(res[i], 1);
+        ASSERT_LE(res[i], 5);
+        cnt[res[i]] += 1;
+    }
+    for (UINT i = 1; i < 5; i++) {
+        ASSERT_GT(cnt[i + 1], cnt[i]);
     }
 }
 


### PR DESCRIPTION
QuantumStateのカバレッジを見て必要だと思ったget_Haar_random_state(), samling(), get_zero_probability(), get_marginal_probability()に対するテストを書きました(get_marginal_probability()はもとからあったことにあとから気づいたので不要なら消します)

### GetHaarRandomState
乱数生成をきっちり統計的に検定するには実行時間がかかる(かつ私が書ける自信がない)ので
- 完全一致の状態がそうかんたんに作られないこと
- seedが等しいときは完全一致すること
- normが1であること
を検証しました

### Sampling
これも乱数の検定が難しいので、見つかる確率が1倍、2倍、…の状態を用意して、単調増加になること、明らかに観測されない状態をサンプリングしないことを確認しました

### GetZeroProbability
Samlingと同じ状態を使って下位4ビット分の確率が手計算と一致することを確認しました