### PR TITLE
add coverage folder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,6 +89,7 @@ pip-delete-this-directory.txt
 
 # Unit test / coverage reports
 htmlcov/
+coverage/
 .tox/
 .coverage
 .coverage.*


### PR DESCRIPTION
close #328 

.gitignoreにcoverage生成で作成されるフォルダを追加します。
