### PR TITLE
add noise simulator test using heavy output

### DIFF
--- a/python/test/test_qulacs.py
+++ b/python/test/test_qulacs.py
@@ -1,10 +1,12 @@
 
 # set library dir
-import qulacs
-import unittest
-import numpy as np
-import warnings
 import sys
+import unittest
+import warnings
+
+import numpy as np
+import qulacs
+
 for ind in range(1, len(sys.argv)):
     sys.path.append(sys.argv[ind])
 sys.argv = sys.argv[:1]
@@ -73,8 +75,8 @@ class TestObservable(unittest.TestCase):
         pass
 
     def test_get_matrix(self):
-        from qulacs import Observable
         import numpy as np
+        from qulacs import Observable
         n_qubits = 3
         obs = Observable(n_qubits)
         obs.add_operator(.5, "Z 2")
@@ -158,11 +160,19 @@ class TestPointerHandling(unittest.TestCase):
 
     def test_circuit_add_gate(self):
         from qulacs import QuantumCircuit, QuantumState
-        from qulacs.gate import Identity, X, Y, Z, H, S, Sdag, T, Tdag, sqrtX, sqrtXdag, sqrtY, sqrtYdag
-        from qulacs.gate import P0, P1, U1, U2, U3, RX, RY, RZ, CNOT, CZ, SWAP, TOFFOLI, FREDKIN, Pauli, PauliRotation
-        from qulacs.gate import DenseMatrix, SparseMatrix, DiagonalMatrix, RandomUnitary, ReversibleBoolean, StateReflection
-        from qulacs.gate import BitFlipNoise, DephasingNoise, IndependentXZNoise, DepolarizingNoise, TwoQubitDepolarizingNoise, AmplitudeDampingNoise, Measurement
-        from qulacs.gate import merge, add, to_matrix_gate, Probabilistic, CPTP, Instrument, Adaptive
+        from qulacs.gate import (CNOT, CPTP, CZ, FREDKIN, P0, P1, RX, RY, RZ,
+                                 SWAP, TOFFOLI, U1, U2, U3, Adaptive,
+                                 AmplitudeDampingNoise, BitFlipNoise,
+                                 DenseMatrix, DephasingNoise,
+                                 DepolarizingNoise, DiagonalMatrix, H,
+                                 Identity, IndependentXZNoise, Instrument,
+                                 Measurement, Pauli, PauliRotation,
+                                 Probabilistic, RandomUnitary,
+                                 ReversibleBoolean, S, Sdag, SparseMatrix,
+                                 StateReflection, T, Tdag,
+                                 TwoQubitDepolarizingNoise, X, Y, Z, add,
+                                 merge, sqrtX, sqrtXdag, sqrtY, sqrtYdag,
+                                 to_matrix_gate)
         from scipy.sparse import lil_matrix
         qc = QuantumCircuit(3)
         qs = QuantumState(3)
@@ -216,12 +226,20 @@ class TestPointerHandling(unittest.TestCase):
 
     def test_circuit_add_parametric_gate(self):
         from qulacs import ParametricQuantumCircuit, QuantumState
-        from qulacs.gate import Identity, X, Y, Z, H, S, Sdag, T, Tdag, sqrtX, sqrtXdag, sqrtY, sqrtYdag
-        from qulacs.gate import P0, P1, U1, U2, U3, RX, RY, RZ, CNOT, CZ, SWAP, TOFFOLI, FREDKIN, Pauli, PauliRotation
-        from qulacs.gate import DenseMatrix, SparseMatrix, DiagonalMatrix, RandomUnitary, ReversibleBoolean, StateReflection
-        from qulacs.gate import BitFlipNoise, DephasingNoise, IndependentXZNoise, DepolarizingNoise, TwoQubitDepolarizingNoise, AmplitudeDampingNoise, Measurement
-        from qulacs.gate import merge, add, to_matrix_gate, Probabilistic, CPTP, Instrument, Adaptive
-        from qulacs.gate import ParametricRX, ParametricRY, ParametricRZ, ParametricPauliRotation
+        from qulacs.gate import (CNOT, CPTP, CZ, FREDKIN, P0, P1, RX, RY, RZ,
+                                 SWAP, TOFFOLI, U1, U2, U3, Adaptive,
+                                 AmplitudeDampingNoise, BitFlipNoise,
+                                 DenseMatrix, DephasingNoise,
+                                 DepolarizingNoise, DiagonalMatrix, H,
+                                 Identity, IndependentXZNoise, Instrument,
+                                 Measurement, ParametricPauliRotation,
+                                 ParametricRX, ParametricRY, ParametricRZ,
+                                 Pauli, PauliRotation, Probabilistic,
+                                 RandomUnitary, ReversibleBoolean, S, Sdag,
+                                 SparseMatrix, StateReflection, T, Tdag,
+                                 TwoQubitDepolarizingNoise, X, Y, Z, add,
+                                 merge, sqrtX, sqrtXdag, sqrtY, sqrtYdag,
+                                 to_matrix_gate)
         from scipy.sparse import lil_matrix
         qc = ParametricQuantumCircuit(3)
         qs = QuantumState(3)
@@ -289,7 +307,8 @@ class TestPointerHandling(unittest.TestCase):
 
     def test_add_same_gate_multiple_time(self):
         from qulacs import QuantumCircuit, QuantumState
-        from qulacs.gate import X, DepolarizingNoise, DephasingNoise, Probabilistic, RX
+        from qulacs.gate import (RX, DephasingNoise, DepolarizingNoise,
+                                 Probabilistic, X)
         state = QuantumState(1)
         circuit = QuantumCircuit(1)
         noise = DepolarizingNoise(0, 0)
@@ -464,8 +483,8 @@ class TestUtils(unittest.TestCase):
         pass
 
     def test_convert_openfermion_op(self):
-        from qulacs.utils import convert_openfermion_op
         from openfermion import QubitOperator
+        from qulacs.utils import convert_openfermion_op
         openfermion_op = QubitOperator()
         openfermion_op += 1. * QubitOperator("X0")
         openfermion_op += 2. * QubitOperator("Z0 Y1")
@@ -616,6 +635,64 @@ class TestDensityMatrixHandling(unittest.TestCase):
         
         pdm = qulacs.state.partial_trace(sv, target)
         self.assertTrue(np.allclose(pdm.get_matrix(), dmt), msg="check pure state partial trace")
+
+
+class TestNoiseSimulator(unittest.TestCase):
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+    
+    def test_noise_simulator(self):
+        def get_heavy_output_probability(n, depth, error_prob, shots=10000):
+            one_qubit_noise = ["Depolarizing", "BitFlip", "Dephasing", "IndependentXZ", "AmplitudeDamping"]
+            two_qubit_noise = ["Depolarizing"]
+            from qulacs.gate import CNOT, CZ, T, sqrtX, sqrtY
+            circuit_with_noise = qulacs.QuantumCircuit(n)
+            circuit_without_noise = qulacs.QuantumCircuit(n)
+            for d in range(depth):
+                for i in range(n):
+                    r = np.random.randint(0, 5)
+                    if r == 0:
+                        circuit_with_noise.add_noise_gate(sqrtX(i), one_qubit_noise[np.random.randint(0, 5)], error_prob)
+                        circuit_without_noise.add_sqrtX_gate(i)
+                    elif r == 1:
+                        circuit_with_noise.add_noise_gate(sqrtY(i), one_qubit_noise[np.random.randint(0, 5)], error_prob)
+                        circuit_without_noise.add_sqrtY_gate(i)
+                    elif r == 2:
+                        circuit_with_noise.add_noise_gate(T(i), one_qubit_noise[np.random.randint(0, 5)], error_prob)
+                        circuit_without_noise.add_T_gate(i)
+                    elif r == 3:
+                        if i + 1 < n:
+                            circuit_with_noise.add_noise_gate(CNOT(i, i + 1), two_qubit_noise[np.random.randint(0, 1)], error_prob)
+                            circuit_without_noise.add_CNOT_gate(i, i + 1)
+                    elif r == 4:
+                        if i + 1 < n:
+                            circuit_with_noise.add_noise_gate(CZ(i, i + 1), two_qubit_noise[np.random.randint(0, 1)], error_prob)
+                            circuit_without_noise.add_CZ_gate(i, i + 1)
+            
+            ideal_state = qulacs.QuantumState(n)
+            circuit_without_noise.update_quantum_state(ideal_state)
+            prob_dist = [abs(x)**2 for x in ideal_state.get_vector()]
+            p_median = np.sort(prob_dist)[2**(n-1) - 1]
+            heavy_output = set()
+            for i in range(2**n):
+                if prob_dist[i] > p_median:
+                    heavy_output.add(i)
+            
+            noisy_state = qulacs.QuantumState(n)
+            circuit_with_noise.update_quantum_state(noisy_state)
+            noisy_sample = noisy_state.sampling(shots)
+            num_heavy_output = 0
+            for sample in noisy_sample:
+                if sample in heavy_output:
+                    num_heavy_output += 1
+            return num_heavy_output / shots
+
+        self.assertGreater(get_heavy_output_probability(10, 100, 0.0001), 2 / 3)
+        self.assertLess(get_heavy_output_probability(10, 100, 0.01), 2 / 3)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/python/test/test_qulacs.py
+++ b/python/test/test_qulacs.py
@@ -690,7 +690,7 @@ class TestNoiseSimulator(unittest.TestCase):
                     num_heavy_output += 1
             return num_heavy_output / shots
 
-        self.assertGreater(get_heavy_output_probability(10, 100, 0.0001), 2 / 3)
+        self.assertGreater(get_heavy_output_probability(10, 100, 1e-5), 2 / 3)
         self.assertLess(get_heavy_output_probability(10, 100, 0.01), 2 / 3)
 
 


### PR DESCRIPTION
close #325 

heavyoutputを測定することでノイズのかかり具合をテストするものを追加しました。(参考: https://github.com/Qulacs-Osaka/quantum_software_handson/blob/main/doc/source/notebooks/04_QuantumVolume.ipynb)

ノイズ無し回路で測定確率中央値以上の基底状態をheavy outputとし、ノイズあり回路を通したあとのサンプリングでheavy outputが出る確率が2/3以上であれば正しく計算されているものとしています。
10 qubit, 100 depthで合計約1000このゲートに対して1e-4の確率のノイズは基本的にかからず、1e-2の確率のノイズはたくさんのるので合わないという内容です。