### PR TITLE
Use python image as base image

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,5 @@
 # See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.209.6/containers/cpp/.devcontainer/base.Dockerfile
 
-# [Choice] Debian / Ubuntu version (use Debian 11/9, Ubuntu 18.04/21.04 on local arm64/Apple Silicon): debian-11, debian-10, debian-9, ubuntu-21.04, ubuntu-20.04, ubuntu-18.04
 ARG VARIANT
 FROM mcr.microsoft.com/vscode/devcontainers/python:0-${VARIANT}
 
@@ -20,6 +19,9 @@ RUN apt-get update \
     cmake \
     libboost-dev \
     && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/*
+
+RUN pip install -U pip \
+    && pip install black flake8 mypy openfermion pybind11-stubgen
 
 # Install cereal
 RUN git clone https://github.com/USCiLab/cereal.git -b v1.3.0 --depth 1 /tmp/cereal \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,17 +1,11 @@
 # See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.209.6/containers/cpp/.devcontainer/base.Dockerfile
 
 # [Choice] Debian / Ubuntu version (use Debian 11/9, Ubuntu 18.04/21.04 on local arm64/Apple Silicon): debian-11, debian-10, debian-9, ubuntu-21.04, ubuntu-20.04, ubuntu-18.04
-ARG VARIANT="bullseye"
-FROM mcr.microsoft.com/vscode/devcontainers/cpp:0-${VARIANT}
+ARG VARIANT
+FROM mcr.microsoft.com/vscode/devcontainers/python:0-${VARIANT}
 
-# [Optional] Uncomment this section to install additional packages.
-# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-#     && apt-get -y install --no-install-recommends <your-package-list-here>
 ENV DEBIAN_FRONTEND=noninteractive
 
-ENV PYTHON_VERSION="3.9.5"
-ENV PYENV_ROOT="/.pyenv"
-ENV PATH="${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"
 ENV PWD="/workspaces/qulacs-osaka"
 ENV QULACS_OSAKA_PACKAGE="qulacs_osaka"
 ENV QULACS_OSAKA_VERSION="0.3.1"
@@ -22,40 +16,10 @@ ENV PYTHONPATH="${PWD}/build/lib.linux-x86_64-3.9:${PYTHONPATH}"
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-    ca-certificates \
     clang-format \
     cmake \
-    curl \
-    gcc \
-    git \
-    g++ \
     libboost-dev \
-    libbz2-dev \
-    libffi-dev \
-    liblzma-dev \
-    libncursesw5-dev \
-    libreadline-dev \
-    libsqlite3-dev \
-    libssl-dev \
-    libxml2-dev \
-    libxmlsec1-dev \
-    llvm \
-    make \
-    python3-dev \
-    python3-distutils \
-    tk-dev \
-    wget \
-    xz-utils \
-    zlib1g-dev
-
-# Install pyenv
-RUN git clone https://github.com/pyenv/pyenv.git ${PYENV_ROOT} \
-    && pyenv install ${PYTHON_VERSION} \
-    && pyenv global ${PYTHON_VERSION} \
-    && pyenv rehash \
-    && python -m pip install --upgrade pip \
-    && pip install black flake8 mypy numpy openfermion pybind11-stubgen scipy wheel \
-    && chmod -R 777 /.pyenv
+    && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/*
 
 # Install cereal
 RUN git clone https://github.com/USCiLab/cereal.git -b v1.3.0 --depth 1 /tmp/cereal \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.209.6/containers/cpp/.devcontainer/base.Dockerfile
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/blob/main/containers/python-3/.devcontainer/base.Dockerfile
 
 ARG VARIANT
 FROM mcr.microsoft.com/vscode/devcontainers/python:0-${VARIANT}
@@ -16,6 +16,7 @@ ENV PYTHONPATH="${PWD}/build/lib.linux-x86_64-3.9:${PYTHONPATH}"
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
     clang-format \
+    gdb \
     cmake \
     libboost-dev \
     && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/*

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,10 +4,11 @@
 	"name": "C++",
 	"build": {
 		"dockerfile": "Dockerfile",
-		// Update 'VARIANT' to pick an Debian / Ubuntu OS version: debian-11, debian-10, debian-9, ubuntu-21.04, ubuntu-20.04, ubuntu-18.04
-		// Use Debian 11, Debian 9, Ubuntu 18.04 or Ubuntu 21.04 on local arm64/Apple Silicon
+		// Update 'VARIANT' to pick a Python version: 3, 3.10, 3.9, 3.8, 3.7, 3.6
+		// Append -bullseye or -buster to pin to an OS version.
+		// Use -bullseye variants on local on arm64/Apple Silicon.
 		"args": {
-			"VARIANT": "debian-11"
+			"VARIANT": "3.9-bullseye"
 		}
 	},
 	"runArgs": [
@@ -30,8 +31,7 @@
 		"python.terminal.activateEnvironment": false,
 		// CAVEAT: you need to restart after building qulacs-osaka to take effect.
 		"C_Cpp.default.includePath": [
-			"include",
-			"/.pyenv/versions/${PYTHON_VERSION}/include/python3.9"
+			"include"
 		]
 	},
 	// Add the IDs of extensions you want installed when the container is created.


### PR DESCRIPTION
close #340 
devcontainer の base image を python に変更しました．
pyenv やもともと存在するツールのインストールは削除しました．
結果的に image のサイズが 2.75GB -> 1.55GB まで減りました．

開発に必要な操作のためのツールがインストールされていることは確認していますが、漏れがあるかもしれないので確認してもらえるとありがたいです 🙏 