### PR TITLE
refactor Parametric Gate/Cirecuit

### DIFF
--- a/src/cppsim/exception.hpp
+++ b/src/cppsim/exception.hpp
@@ -177,6 +177,20 @@ public:
 };
 
 /**
+ * \~japanese-en ParametricGateのupdate_funcが定義されていないという例外
+ */
+class UndefinedUpdateFuncException : public std::logic_error {
+public:
+    /**
+     * \~japanese-en コンストラクタ
+     *
+     * @param message エラーメッセージ
+     */
+    UndefinedUpdateFuncException(const std::string& message)
+        : std::logic_error(message) {}
+};
+
+/**
  * \~japanese-en
  * GeneralQuantumOperator中のPauliOperatorのインデックスが範囲外という例外
  */
@@ -230,6 +244,20 @@ public:
      * @param message エラーメッセージ
      */
     GateIndexOutOfRangeException(const std::string& message)
+        : std::out_of_range(message) {}
+};
+
+/**
+ * \~japanese-en ParametricCircuitのパラメータのインデックスが範囲外という例外
+ */
+class ParameterIndexOutOfRangeException : public std::out_of_range {
+public:
+    /**
+     * \~japanese-en コンストラクタ
+     *
+     * @param message エラーメッセージ
+     */
+    ParameterIndexOutOfRangeException(const std::string& message)
         : std::out_of_range(message) {}
 };
 

--- a/src/vqcsim/parametric_circuit.cpp
+++ b/src/vqcsim/parametric_circuit.cpp
@@ -18,10 +18,13 @@ ParametricQuantumCircuit::ParametricQuantumCircuit(UINT qubit_count_)
 ParametricQuantumCircuit* ParametricQuantumCircuit::copy() const {
     ParametricQuantumCircuit* new_circuit =
         new ParametricQuantumCircuit(this->qubit_count);
+    UINT pos = 0;
     for (UINT gate_pos = 0; gate_pos < this->gate_list.size(); gate_pos++) {
-        auto pos = std::find(this->_parametric_gate_position.begin(),
-            this->_parametric_gate_position.end(), gate_pos);
-        bool is_parametric = (pos != this->_parametric_gate_position.end());
+        while (pos < _parametric_gate_position.size() &&
+               _parametric_gate_position[pos] < gate_pos)
+            pos++;
+        bool is_parametric = (pos < _parametric_gate_position.size() &&
+                              _parametric_gate_position[pos] == gate_pos);
 
         if (is_parametric) {
             new_circuit->add_parametric_gate(
@@ -67,21 +70,18 @@ UINT ParametricQuantumCircuit::get_parameter_count() const {
 }
 double ParametricQuantumCircuit::get_parameter(UINT index) const {
     if (index >= this->_parametric_gate_list.size()) {
-        std::cerr << "Error: ParametricQuantumCircuit::get_parameter(UINT): "
-                     "parameter index is out of range"
-                  << std::endl;
-        return 0.;
+        throw ParameterIndexOutOfRangeException(
+            "Error: ParametricQuantumCircuit::get_parameter(UINT): parameter "
+            "index is out of range");
     }
 
     return _parametric_gate_list[index]->get_parameter_value();
 }
 void ParametricQuantumCircuit::set_parameter(UINT index, double value) {
     if (index >= this->_parametric_gate_list.size()) {
-        std::cerr
-            << "Error: ParametricQuantumCircuit::set_parameter(UINT,double): "
-               "parameter index is out of range"
-            << std::endl;
-        return;
+        throw ParameterIndexOutOfRangeException(
+            "Error: ParametricQuantumCircuit::set_parameter(UINT,double): "
+            "parameter index is out of range");
     }
 
     _parametric_gate_list[index]->set_parameter_value(value);
@@ -108,11 +108,10 @@ std::ostream& operator<<(
 
 UINT ParametricQuantumCircuit::get_parametric_gate_position(UINT index) const {
     if (index >= this->_parametric_gate_list.size()) {
-        std::cerr
-            << "Error: "
-               "ParametricQuantumCircuit::get_parametric_gate_position(UINT):"
-               " parameter index is out of range"
-            << std::endl;
+        throw ParameterIndexOutOfRangeException(
+            "Error: "
+            "ParametricQuantumCircuit::get_parametric_gate_position(UINT): "
+            "parameter index is out of range");
         return 0;
     }
 

--- a/src/vqcsim/parametric_circuit.cpp
+++ b/src/vqcsim/parametric_circuit.cpp
@@ -39,30 +39,28 @@ ParametricQuantumCircuit* ParametricQuantumCircuit::copy() const {
 
 void ParametricQuantumCircuit::add_parametric_gate(
     QuantumGate_SingleParameter* gate) {
-    _parametric_gate_position.push_back((UINT)gate_list.size());
     this->add_gate(gate);
+    _parametric_gate_position.push_back((UINT)gate_list.size() - 1);
     _parametric_gate_list.push_back(gate);
 };
 void ParametricQuantumCircuit::add_parametric_gate(
     QuantumGate_SingleParameter* gate, UINT index) {
-    _parametric_gate_position.push_back(index);
     this->add_gate(gate, index);
+    _parametric_gate_position.push_back(index);
     _parametric_gate_list.push_back(gate);
 }
 void ParametricQuantumCircuit::add_parametric_gate_copy(
     QuantumGate_SingleParameter* gate) {
-    _parametric_gate_position.push_back((UINT)gate_list.size());
     QuantumGate_SingleParameter* copied_gate = gate->copy();
-    QuantumCircuit::add_gate(copied_gate);
+    this->add_gate(copied_gate);
+    _parametric_gate_position.push_back((UINT)gate_list.size() - 1);
     _parametric_gate_list.push_back(copied_gate);
 };
 void ParametricQuantumCircuit::add_parametric_gate_copy(
     QuantumGate_SingleParameter* gate, UINT index) {
-    for (auto& val : _parametric_gate_position)
-        if (val >= index) val++;
-    _parametric_gate_position.push_back(index);
     QuantumGate_SingleParameter* copied_gate = gate->copy();
-    QuantumCircuit::add_gate(copied_gate, index);
+    this->add_gate(copied_gate, index);
+    _parametric_gate_position.push_back(index);
     _parametric_gate_list.push_back(copied_gate);
 }
 UINT ParametricQuantumCircuit::get_parameter_count() const {

--- a/src/vqcsim/parametric_circuit.cpp
+++ b/src/vqcsim/parametric_circuit.cpp
@@ -110,7 +110,6 @@ UINT ParametricQuantumCircuit::get_parametric_gate_position(UINT index) const {
             "Error: "
             "ParametricQuantumCircuit::get_parametric_gate_position(UINT): "
             "parameter index is out of range");
-        return 0;
     }
 
     return _parametric_gate_position[index];

--- a/src/vqcsim/parametric_circuit.cpp
+++ b/src/vqcsim/parametric_circuit.cpp
@@ -18,13 +18,10 @@ ParametricQuantumCircuit::ParametricQuantumCircuit(UINT qubit_count_)
 ParametricQuantumCircuit* ParametricQuantumCircuit::copy() const {
     ParametricQuantumCircuit* new_circuit =
         new ParametricQuantumCircuit(this->qubit_count);
-    UINT pos = 0;
     for (UINT gate_pos = 0; gate_pos < this->gate_list.size(); gate_pos++) {
-        while (pos < _parametric_gate_position.size() &&
-               _parametric_gate_position[pos] < gate_pos)
-            pos++;
-        bool is_parametric = (pos < _parametric_gate_position.size() &&
-                              _parametric_gate_position[pos] == gate_pos);
+        auto pos = std::find(this->_parametric_gate_position.begin(),
+            this->_parametric_gate_position.end(), gate_pos);
+        bool is_parametric = (pos != this->_parametric_gate_position.end());
 
         if (is_parametric) {
             new_circuit->add_parametric_gate(

--- a/src/vqcsim/parametric_gate.hpp
+++ b/src/vqcsim/parametric_gate.hpp
@@ -55,9 +55,19 @@ public:
                 _update_func_gpu(this->_target_qubit_list[0].index(), _angle,
                     state->data(), state->dim, state->get_cuda_stream(),
                     state->device_number);
+                return;
             }
-            return;
 #endif
+            if (_update_func == NULL) {
+                throw UndefinedUpdateFuncException(
+                    "Error: "
+                    "QuantumGate_SingleParameterOneQubitRotation::update_"
+                    "quantum_state(QuantumStateBase) : update function is "
+                    "undefined");
+            }
+            _update_func(this->_target_qubit_list[0].index(), _angle,
+                state->data_c(), state->dim);
+        } else {
             if (_update_func_dm == NULL) {
                 throw UndefinedUpdateFuncException(
                     "Error: "
@@ -68,7 +78,7 @@ public:
             _update_func_dm(this->_target_qubit_list[0].index(), _angle,
                 state->data_c(), state->dim);
         }
-    };
+    }
 };
 
 class ClsParametricRXGate : public QuantumGate_SingleParameterOneQubitRotation {

--- a/src/vqcsim/parametric_gate.hpp
+++ b/src/vqcsim/parametric_gate.hpp
@@ -33,9 +33,9 @@ class QuantumGate_SingleParameterOneQubitRotation
 protected:
     typedef void(T_UPDATE_FUNC)(UINT, double, CTYPE*, ITYPE);
     typedef void(T_GPU_UPDATE_FUNC)(UINT, double, void*, ITYPE, void*, UINT);
-    T_UPDATE_FUNC* _update_func;
-    T_UPDATE_FUNC* _update_func_dm;
-    T_GPU_UPDATE_FUNC* _update_func_gpu;
+    T_UPDATE_FUNC* _update_func = NULL;
+    T_UPDATE_FUNC* _update_func_dm = NULL;
+    T_GPU_UPDATE_FUNC* _update_func_gpu = NULL;
 
     QuantumGate_SingleParameterOneQubitRotation(double angle)
         : QuantumGate_SingleParameter(angle) {}

--- a/src/vqcsim/parametric_gate.hpp
+++ b/src/vqcsim/parametric_gate.hpp
@@ -46,7 +46,7 @@ public:
 #ifdef _USE_GPU
             if (state->get_device_name() == "gpu") {
                 if (_update_func_gpu == NULL) {
-                    UndefinedUpdateFuncException(
+                    throw UndefinedUpdateFuncException(
                         "Error: "
                         "QuantumGate_SingleParameterOneQubitRotation::update_"
                         "quantum_state(QuantumStateBase) : update function is "
@@ -57,7 +57,7 @@ public:
                     state->device_number);
             } else {
                 if (_update_func == NULL) {
-                    UndefinedUpdateFuncException(
+                    throw UndefinedUpdateFuncException(
                         "Error: "
                         "QuantumGate_SingleParameterOneQubitRotation::update_"
                         "quantum_state(QuantumStateBase) : update function is "
@@ -68,7 +68,7 @@ public:
             }
 #else
             if (_update_func == NULL) {
-                UndefinedUpdateFuncException(
+                throw UndefinedUpdateFuncException(
                     "Error: "
                     "QuantumGate_SingleParameterOneQubitRotation::update_"
                     "quantum_state(QuantumStateBase) : update function is "
@@ -79,7 +79,7 @@ public:
 #endif
         } else {
             if (_update_func_dm == NULL) {
-                UndefinedUpdateFuncException(
+                throw UndefinedUpdateFuncException(
                     "Error: "
                     "QuantumGate_SingleParameterOneQubitRotation::update_"
                     "quantum_state(QuantumStateBase) : update function is "

--- a/src/vqcsim/parametric_gate.hpp
+++ b/src/vqcsim/parametric_gate.hpp
@@ -55,29 +55,9 @@ public:
                 _update_func_gpu(this->_target_qubit_list[0].index(), _angle,
                     state->data(), state->dim, state->get_cuda_stream(),
                     state->device_number);
-            } else {
-                if (_update_func == NULL) {
-                    throw UndefinedUpdateFuncException(
-                        "Error: "
-                        "QuantumGate_SingleParameterOneQubitRotation::update_"
-                        "quantum_state(QuantumStateBase) : update function is "
-                        "undefined");
-                }
-                _update_func(this->_target_qubit_list[0].index(), _angle,
-                    state->data_c(), state->dim);
             }
-#else
-            if (_update_func == NULL) {
-                throw UndefinedUpdateFuncException(
-                    "Error: "
-                    "QuantumGate_SingleParameterOneQubitRotation::update_"
-                    "quantum_state(QuantumStateBase) : update function is "
-                    "undefined");
-            }
-            _update_func(this->_target_qubit_list[0].index(), _angle,
-                state->data_c(), state->dim);
+            return;
 #endif
-        } else {
             if (_update_func_dm == NULL) {
                 throw UndefinedUpdateFuncException(
                     "Error: "

--- a/test/vqcsim/test.cpp
+++ b/test/vqcsim/test.cpp
@@ -70,6 +70,29 @@ TEST(ParametricCircuit, GateApplyDM) {
     delete circuit;
 }
 
+TEST(ParametricCircuit, ParametricGatePosition) {
+    auto circuit = ParametricQuantumCircuit(3);
+    circuit.add_parametric_RX_gate(0, 0.);
+    circuit.add_H_gate(0);
+    circuit.add_parametric_RZ_gate(0, 0.);
+    circuit.add_CNOT_gate(0, 1);
+    circuit.add_parametric_RY_gate(1, 0.);
+    circuit.add_parametric_gate(gate::ParametricRY(2), 2);
+    circuit.add_parametric_gate(gate::ParametricRZ(0), 2);
+    circuit.add_parametric_gate(gate::ParametricRZ(1), 0);
+    circuit.remove_gate(4);
+    circuit.remove_gate(5);
+    circuit.add_parametric_gate(gate::ParametricPauliRotation({1}, {0}, 0.), 6);
+
+    ASSERT_EQ(circuit.get_parameter_count(), 6);
+    ASSERT_EQ(circuit.get_parametric_gate_position(0), 1);
+    ASSERT_EQ(circuit.get_parametric_gate_position(1), 4);
+    ASSERT_EQ(circuit.get_parametric_gate_position(2), 5);
+    ASSERT_EQ(circuit.get_parametric_gate_position(3), 3);
+    ASSERT_EQ(circuit.get_parametric_gate_position(4), 0);
+    ASSERT_EQ(circuit.get_parametric_gate_position(5), 6);
+}
+
 class MyRandomCircuit : public ParametricCircuitBuilder {
     ParametricQuantumCircuit* create_circuit(
         UINT output_dim, UINT param_count) const override {

--- a/test/vqcsim/test.cpp
+++ b/test/vqcsim/test.cpp
@@ -74,23 +74,22 @@ TEST(ParametricCircuit, ParametricGatePosition) {
     auto circuit = ParametricQuantumCircuit(3);
     circuit.add_parametric_RX_gate(0, 0.);
     circuit.add_H_gate(0);
-    circuit.add_parametric_RZ_gate(0, 0.);
-    circuit.add_CNOT_gate(0, 1);
+    circuit.add_parametric_gate_copy(gate::ParametricRZ(0, 0.));
+    circuit.add_gate_copy(gate::CNOT(0, 1));
     circuit.add_parametric_RY_gate(1, 0.);
     circuit.add_parametric_gate(gate::ParametricRY(2), 2);
-    circuit.add_parametric_gate(gate::ParametricRZ(0), 2);
+    circuit.add_gate_copy(gate::X(0), 2);
     circuit.add_parametric_gate(gate::ParametricRZ(1), 0);
     circuit.remove_gate(4);
     circuit.remove_gate(5);
     circuit.add_parametric_gate(gate::ParametricPauliRotation({1}, {0}, 0.), 6);
 
-    ASSERT_EQ(circuit.get_parameter_count(), 6);
+    ASSERT_EQ(circuit.get_parameter_count(), 5);
     ASSERT_EQ(circuit.get_parametric_gate_position(0), 1);
     ASSERT_EQ(circuit.get_parametric_gate_position(1), 4);
     ASSERT_EQ(circuit.get_parametric_gate_position(2), 5);
-    ASSERT_EQ(circuit.get_parametric_gate_position(3), 3);
-    ASSERT_EQ(circuit.get_parametric_gate_position(4), 0);
-    ASSERT_EQ(circuit.get_parametric_gate_position(5), 6);
+    ASSERT_EQ(circuit.get_parametric_gate_position(3), 0);
+    ASSERT_EQ(circuit.get_parametric_gate_position(4), 6);
 }
 
 class MyRandomCircuit : public ParametricCircuitBuilder {

--- a/test/vqcsim/test.cpp
+++ b/test/vqcsim/test.cpp
@@ -10,6 +10,27 @@
 #include <vqcsim/problem.hpp>
 #include <vqcsim/solver.hpp>
 
+class ClsParametricNullUpdateGate
+    : public QuantumGate_SingleParameterOneQubitRotation {
+public:
+    ClsParametricNullUpdateGate(UINT target_qubit_index, double angle)
+        : QuantumGate_SingleParameterOneQubitRotation(angle) {
+        this->_name = "ParametricNullUpdate";
+        this->_target_qubit_list.push_back(TargetQubitInfo(target_qubit_index));
+    }
+    virtual void set_matrix(ComplexMatrix& matrix) const override {}
+    virtual QuantumGate_SingleParameter* copy() const override {
+        return new ClsParametricNullUpdateGate(*this);
+    };
+};
+
+TEST(ParametricGate, NullUpdateFunc) {
+    ClsParametricNullUpdateGate gate(0, 0.);
+    QuantumState state(1);
+    ASSERT_THROW(
+        gate.update_quantum_state(&state), UndefinedUpdateFuncException);
+}
+
 TEST(ParametricCircuit, GateApply) {
     const UINT n = 3;
     const UINT depth = 10;

--- a/test/vqcsim/test.cpp
+++ b/test/vqcsim/test.cpp
@@ -82,7 +82,8 @@ TEST(ParametricCircuit, ParametricGatePosition) {
     circuit.add_parametric_gate(gate::ParametricRZ(1), 0);
     circuit.remove_gate(4);
     circuit.remove_gate(5);
-    circuit.add_parametric_gate(gate::ParametricPauliRotation({1}, {0}, 0.), 6);
+    circuit.add_parametric_gate_copy(
+        gate::ParametricPauliRotation({1}, {0}, 0.), 6);
 
     ASSERT_EQ(circuit.get_parameter_count(), 5);
     ASSERT_EQ(circuit.get_parametric_gate_position(0), 1);


### PR DESCRIPTION
ParametricGateとParametricCircuitの実装を読んで気になったところを書き換えました
1. QuantumGate_SingleParameterのコンストラクタの`_gate_property`のスイッチ、xorだともし継承して同じことをもう一回書いたら0になってしまうリスクがあるので意味的に正しいorにした
2. QuantumGate_SignelParameterOneQubitRotationのコンストラクタで、親クラスのコンストラクタで行われていることが2回発生していてそうだったので削除した
3. QuantumGate_SingleParameterOneQubitRotationは他のクラスで継承することを前提としているはずで、もしそのままインスタンス化して使われた場合にupdate_funcがNULLのときに困るので例外を追加した
4. ParametricCircuitのcopy()でstd::find()を使ってるが、_parametric_gate_positionは必ず単調増加で、検索クエリも単調増加なため`pos`をカーソルとしてO(gate_num)で探索するように変更した
5. parameterをget/setする用途の関数での配列外参照がただのエラー出力になっていたので例外対応した

3はよく考えたらQuantumGate_SingleParameterOneQubitRotationが純粋仮想関数を持っていてインスタンス化できないので起こり得ない事故への対処になってました。
不要なら消します。