### PR TITLE
NoisyEvolutionのc_opsに空が指定されるとsegmentation faultする

### DIFF
--- a/src/cppsim/gate_noisy_evolution.hpp
+++ b/src/cppsim/gate_noisy_evolution.hpp
@@ -330,9 +330,11 @@ public:
                 auto index = std::distance(cumulative_dist.begin(), ite);
 
                 // apply the collapse operator and normalize the state
-                _c_ops[index]->apply_to_state_single_thread(state, buffer);
-                buffer->normalize(buffer->get_squared_norm_single_thread());
-                state->load(buffer);
+                if (_c_ops.size() > index) {
+                    _c_ops[index]->apply_to_state_single_thread(state, buffer);
+                    buffer->normalize(buffer->get_squared_norm_single_thread());
+                    state->load(buffer);
+                }
 
                 // update dt to be consistent with the step size
                 t += dt_target_norm;

--- a/src/cppsim/gate_noisy_evolution.hpp
+++ b/src/cppsim/gate_noisy_evolution.hpp
@@ -330,6 +330,10 @@ public:
                 auto index = std::distance(cumulative_dist.begin(), ite);
 
                 // apply the collapse operator and normalize the state
+                // ルンゲクッタ法の誤差により、normが1にならない場合があります。
+                // その場合に本来collapseが起こらないはずなのに起きる分岐に入ってしまいます。
+                // そして、c_opsが空の場合に不正アクセスとなります。
+                // coefが0の場合でも、各collapseが発生する確率は0なので、0除算が発生してしまいます。
                 if (_c_ops.size() > index) {
                     _c_ops[index]->apply_to_state_single_thread(state, buffer);
                     buffer->normalize(buffer->get_squared_norm_single_thread());

--- a/test/cppsim/test_noisyevolution.cpp
+++ b/test/cppsim/test_noisyevolution.cpp
@@ -265,3 +265,35 @@ TEST(NoisyEvolutionTest, check_inf_occurence) {
             std::isinf(observable.get_expectation_value(&state).real()));
     }
 }
+
+TEST(NoisyEvolutionTest, EmptyCops) {
+    double gamma = 0.5474999999999999;
+    double depth = 10;
+    double dt = 0.8;
+    double time = dt * depth;
+
+    UINT n = 4;
+    Observable observable(n);
+    observable.add_operator(1, "X 0");
+    Observable hamiltonian(n);
+    for (UINT i = 0; i < n; i++) {
+        std::string s = "X ";
+        s += std::to_string(i);
+        hamiltonian.add_operator(gamma, s);
+    }
+
+    std::vector<GeneralQuantumOperator*> c_ops;
+
+    QuantumState state(n);
+    QuantumCircuit circuit(n);
+    auto gate = dynamic_cast<ClsNoisyEvolution*>(
+        gate::NoisyEvolution(&hamiltonian, c_ops, time, dt));
+    circuit.add_gate(gate);
+    for (int k = 0; k < n; k++) {
+        std::cout << "set_computational_basis:" << k << std::endl;
+        state.set_computational_basis(k);
+        circuit.update_quantum_state(&state);
+        ASSERT_FALSE(
+            std::isinf(observable.get_expectation_value(&state).real()));
+    }
+}

--- a/test/cppsim/test_noisyevolution.cpp
+++ b/test/cppsim/test_noisyevolution.cpp
@@ -282,6 +282,7 @@ TEST(NoisyEvolutionTest, EmptyCops) {
         hamiltonian.add_operator(gamma, s);
     }
 
+    // c_opsが空の場合にセグフォとなっていたので、テストを追加
     std::vector<GeneralQuantumOperator*> c_ops;
 
     QuantumState state(n);
@@ -293,6 +294,7 @@ TEST(NoisyEvolutionTest, EmptyCops) {
         std::cout << "set_computational_basis:" << k << std::endl;
         state.set_computational_basis(k);
         circuit.update_quantum_state(&state);
+        // セグフォとならずに期待値が取れればよい
         ASSERT_FALSE(
             std::isinf(observable.get_expectation_value(&state).real()));
     }


### PR DESCRIPTION
c_opsのサイズとindexをチェックするようにしました。テストも追加しました。