### PR TITLE
Explicitly git clone to /qulacs

### DIFF
--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -150,7 +150,7 @@ jobs:
       # This job is running on a docker container.
       # We can't use actions/checkout because Node.js is not installed on the container.
       # Therefore, we use `git clone` instead of actions/checkout.
-      - name: clone /qulacs (pull_request)
+      - name: Clone /qulacs (pull_request)
         if: ${{ github.event_name == 'pull_request' }}
         env:
           # We use $REPOSITORY to support PR from the forked repository of Qulacs-Osaka/qulacs-osaka.
@@ -159,13 +159,13 @@ jobs:
           cd /
           git clone -b "${GITHUB_HEAD_REF#refs/*/}" https://github.com/$REPOSITORY /qulacs
 
-      - name: clone /qulacs-osaka (push)
+      - name: Clone /qulacs (push)
         if: ${{ github.event_name == 'push' }}
         run: |
           cd /
           git clone -b "${GITHUB_REF#refs/*/}" https://github.com/${GITHUB_REPOSITORY} /qulacs
 
-      - name: format
+      - name: Format
         run: qulacs_format
 
       - name: Compare diff

--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -157,13 +157,13 @@ jobs:
           REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
         run: |
           cd /
-          git clone -b "${GITHUB_HEAD_REF#refs/*/}" https://github.com/$REPOSITORY
+          git clone -b "${GITHUB_HEAD_REF#refs/*/}" https://github.com/$REPOSITORY /qulacs
 
       - name: clone /qulacs-osaka (push)
         if: ${{ github.event_name == 'push' }}
         run: |
           cd /
-          git clone -b "${GITHUB_REF#refs/*/}" https://github.com/${GITHUB_REPOSITORY}
+          git clone -b "${GITHUB_REF#refs/*/}" https://github.com/${GITHUB_REPOSITORY} /qulacs
 
       - name: format
         run: qulacs_format

--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -170,7 +170,7 @@ jobs:
 
       - name: Compare diff
         run: |
-          cd /qulacs-osaka
+          cd /qulacs
           diff=$(git diff)
           echo -n "$diff"
           # Without `-n`, `echo -n "$diff" | wc -l` is 1 even if `"$diff" is empty.`

--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -150,7 +150,7 @@ jobs:
       # This job is running on a docker container.
       # We can't use actions/checkout because Node.js is not installed on the container.
       # Therefore, we use `git clone` instead of actions/checkout.
-      - name: clone /qulacs-osaka (pull_request)
+      - name: clone /qulacs (pull_request)
         if: ${{ github.event_name == 'pull_request' }}
         env:
           # We use $REPOSITORY to support PR from the forked repository of Qulacs-Osaka/qulacs-osaka.


### PR DESCRIPTION
[qulacs-docker-images#6](https://github.com/Qulacs-Osaka/qulacs-docker-images/pull/6) で，clang-format のコンテナにおいてはプロジェクトが `/qulacs` に存在することを前提にするようにしたため，clang-format の CI で `/qulacs` に git clone するようにしました．
↑の PR がマージされて新しいイメージが publish されるまでこの PR の CI はパスしないため，draft にしておきます．