### PR TITLE
plan1: use parameter in global

### DIFF
--- a/src/cppsim/exception.hpp
+++ b/src/cppsim/exception.hpp
@@ -248,17 +248,33 @@ public:
 };
 
 /**
- * \~japanese-en ParametricCircuitのパラメータのインデックスが範囲外という例外
+ * \~japanese-en
+ * ParameterKeyが与えられたParameterSetやグローバルに存在しないという例外
  */
-class ParameterIndexOutOfRangeException : public std::out_of_range {
+class ParameterKeyNotFoundException : public std::logic_error {
 public:
     /**
      * \~japanese-en コンストラクタ
      *
      * @param message エラーメッセージ
      */
-    ParameterIndexOutOfRangeException(const std::string& message)
-        : std::out_of_range(message) {}
+    ParameterKeyNotFoundException(const std::string& message)
+        : std::logic_error(message) {}
+};
+
+/**
+ * \~japanese-en
+ * ParametricCircuitのParameterSetの作ろうとしたIDがすでに存在するという例外
+ */
+class ParameterIdDuplicatedException : public std::logic_error {
+public:
+    /**
+     * \~japanese-en コンストラクタ
+     *
+     * @param message エラーメッセージ
+     */
+    ParameterIdDuplicatedException(const std::string& message)
+        : std::logic_error(message) {}
 };
 
 /**

--- a/src/vqcsim/parameter.cpp
+++ b/src/vqcsim/parameter.cpp
@@ -1,0 +1,68 @@
+#include "parameter.hpp"
+
+namespace parameter {
+std::vector<double> parameter_list;
+ParameterType get_parameter_type(const ParameterKey& parameter_key) {
+    auto it = std::find(parameter_key.begin(), parameter_key.end(), ':');
+    assert(it != parameter_key.end());
+    return std::string(parameter_key.begin(), it);
+}
+ParameterId get_parameter_id(const ParameterKey& parameter_key) {
+    auto it = std::find(parameter_key.begin(), parameter_key.end(), ':');
+    assert(it != parameter_key.end());
+    return std::string(it + 1, parameter_key.end());
+}
+
+ParameterKey create_parameter(double parameter) {
+    UINT index = parameter_list.size();
+    parameter_list.push_back(parameter);
+    return "global:" + std::to_string(index);
+}
+void set_parameter_value(const ParameterKey& parameter_key, double parameter,
+    ParameterSet& parameter_set) {
+    ParameterType ptype = get_parameter_type(parameter_key);
+    ParameterType pid = get_parameter_id(parameter_key);
+    if (ptype == "user") {
+        auto it = parameter_set.find(pid);
+        if (it != parameter_set.end()) {
+            parameter_set[pid] = parameter;
+            return;
+        }
+    }
+    if (ptype == "global") {
+        UINT pid_int = std::stoi(pid);
+        if (pid_int < parameter::parameter_list.size()) {
+            parameter::parameter_list[pid_int] = parameter;
+            return;
+        }
+    }
+    throw ParameterKeyNotFoundException(
+        "Error: parameter_internal::set_parameter_value("
+        "const ParameterKey&, double, parameter_set&): parameter_key" +
+        parameter_key + "is not found in parameter_set or global");
+}
+void set_parameter_value(const ParameterKey& parameter_key, double parameter) {
+    ParameterSet dummy;
+    set_parameter_value(parameter_key, parameter, dummy);
+}
+double get_parameter_value(
+    const ParameterKey& parameter_key, const ParameterSet& parameter_set = {}) {
+    ParameterType ptype = get_parameter_type(parameter_key);
+    ParameterType pid = get_parameter_id(parameter_key);
+    if (ptype == "user") {
+        auto it = parameter_set.find(pid);
+        if (it != parameter_set.end()) return it->second;
+    }
+    if (ptype == "global") {
+        UINT pid_int = std::stoi(pid);
+        if (pid_int < parameter::parameter_list.size()) {
+            return parameter::parameter_list[pid_int];
+        }
+    }
+    throw ParameterKeyNotFoundException(
+        "Error: parameter_internal::get_parameter_value(const ParameterKey&, "
+        "const ParameterSet&): parameter_key" +
+        parameter_key + "is not found in parameter_set or global");
+}
+
+}  // namespace parameter

--- a/src/vqcsim/parameter.cpp
+++ b/src/vqcsim/parameter.cpp
@@ -21,7 +21,7 @@ ParameterKey create_parameter(double parameter) {
 void set_parameter_value(const ParameterKey& parameter_key, double parameter,
     ParameterSet& parameter_set) {
     ParameterType ptype = get_parameter_type(parameter_key);
-    ParameterType pid = get_parameter_id(parameter_key);
+    ParameterId pid = get_parameter_id(parameter_key);
     if (ptype == "user") {
         auto it = parameter_set.find(pid);
         if (it != parameter_set.end()) {
@@ -48,7 +48,7 @@ void set_parameter_value(const ParameterKey& parameter_key, double parameter) {
 double get_parameter_value(
     const ParameterKey& parameter_key, const ParameterSet& parameter_set = {}) {
     ParameterType ptype = get_parameter_type(parameter_key);
-    ParameterType pid = get_parameter_id(parameter_key);
+    ParameterId pid = get_parameter_id(parameter_key);
     if (ptype == "user") {
         auto it = parameter_set.find(pid);
         if (it != parameter_set.end()) return it->second;

--- a/src/vqcsim/parameter.hpp
+++ b/src/vqcsim/parameter.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <algorithm>
+#include <cassert>
+#include <cppsim/exception.hpp>
+#include <csim/type.hpp>
+#include <map>
+#include <string>
+#include <vector>
+
+using ParameterType = std::string;
+using ParameterId = std::string;
+using ParameterKey = std::string;
+using ParameterSet = std::map<ParameterKey, double>;
+
+namespace parameter {
+ParameterType get_parameter_type(const ParameterKey& parameter_key);
+ParameterId get_parameter_id(const ParameterKey& parameter_key);
+ParameterKey create_parameter(double parameter);
+extern std::vector<double> parameter_list;
+void set_parameter_value(const ParameterKey& parameter_key, double parameter,
+    ParameterSet& parameter_set);
+void set_parameter_value(const ParameterKey& parameter_key, double parameter);
+double get_parameter_value(
+    const ParameterKey& parameter_key, const ParameterSet& parameter_set);
+
+}  // namespace parameter

--- a/src/vqcsim/parameter.hpp
+++ b/src/vqcsim/parameter.hpp
@@ -11,7 +11,7 @@
 using ParameterType = std::string;
 using ParameterId = std::string;
 using ParameterKey = std::string;
-using ParameterSet = std::map<ParameterKey, double>;
+using ParameterSet = std::map<ParameterId, double>;
 
 namespace parameter {
 ParameterType get_parameter_type(const ParameterKey& parameter_key);

--- a/src/vqcsim/parametric_circuit.cpp
+++ b/src/vqcsim/parametric_circuit.cpp
@@ -31,7 +31,8 @@ ParametricQuantumCircuit* ParametricQuantumCircuit::copy() const {
     for (UINT i = 0; i < this->_parametric_gate_position.size(); i++) {
         UINT index = _parametric_gate_position[i];
         new_circuit->_parametric_gate_list[i] =
-            dynamic_cast<QuantumGate_SingleParameter*>(this->_gate_list[index]);
+            dynamic_cast<QuantumGate_SingleParameter*>(
+                new_circuit->_gate_list[index]);
     }
     return new_circuit;
 }
@@ -408,8 +409,5 @@ void ParametricQuantumCircuit::add_parametric_multi_Pauli_rotation_gate(
         gate::ParametricPauliRotation(target, pauli_id, parameter_key));
 }
 UINT ParametricQuantumCircuit::get_parameter_count() const {
-    throw NotImplementedException(
-        "Error: ParametricQuantumCircuit::get_parameter_count(): This function "
-        "is no longer supported. Use get_parameter_id_count() or "
-        "get_parametric_gate_count() instead.");
+    return this->_parametric_gate_list.size();
 }

--- a/src/vqcsim/parametric_circuit.hpp
+++ b/src/vqcsim/parametric_circuit.hpp
@@ -3,15 +3,21 @@
 #include <cppsim/circuit.hpp>
 #include <cppsim/observable.hpp>
 #include <cppsim/state.hpp>
+
+#include "parametric_gate.hpp"
+
 class QuantumGate_SingleParameter;
 
 class DllExport ParametricQuantumCircuit : public QuantumCircuit {
 private:
     std::vector<QuantumGate_SingleParameter*> _parametric_gate_list;
     std::vector<UINT> _parametric_gate_position;
+    ParameterSet _parameter_set;
 
 public:
     ParametricQuantumCircuit(UINT qubit_count);
+    ParametricQuantumCircuit(
+        UINT qubit_count, const ParameterSet& parameter_set);
 
     ParametricQuantumCircuit* copy() const;
 
@@ -21,9 +27,17 @@ public:
     virtual void add_parametric_gate_copy(QuantumGate_SingleParameter* gate);
     virtual void add_parametric_gate_copy(
         QuantumGate_SingleParameter* gate, UINT index);
-    virtual UINT get_parameter_count() const;
-    virtual double get_parameter(UINT index) const;
-    virtual void set_parameter(UINT index, double value);
+    virtual std::vector<ParameterId> get_parameter_id_list() const;
+    virtual UINT get_parameter_id_count() const;
+    virtual UINT get_parametric_gate_count() const;
+    virtual void create_parameter(
+        const ParameterId& parameter_id, double initial_parameter);
+    virtual void remove_parameter(const ParameterId& parameter_id);
+    bool contains_parameter(const ParameterId& parameter_id) const;
+    virtual double get_parameter(const ParameterId& parameter_id) const;
+    virtual void set_parameter(const ParameterId& parameter_id, double value);
+    virtual ParameterSet get_parameter_set() const;
+    virtual void set_parameter_set(const ParameterSet& parameter_set);
 
     virtual UINT get_parametric_gate_position(UINT index) const;
     virtual void add_gate(QuantumGateBase* gate) override;
@@ -50,6 +64,34 @@ public:
     friend DllExport std::ostream& operator<<(
         std::ostream& os, const ParametricQuantumCircuit* circuit);
 
+    virtual void add_parametric_RX_gate_new_parameter(UINT target_index,
+        const ParameterId& parameter_id, double initial_parameter,
+        double parameter_coef = 1.);
+    virtual void add_parametric_RX_gate_share_parameter(UINT target_index,
+        const ParameterId& parameter_id, double parameter_coef = 1.);
+    virtual void add_parametric_RY_gate_new_parameter(UINT target_index,
+        const ParameterId& parameter_id, double initial_parameter,
+        double parameter_coef = 1.);
+    virtual void add_parametric_RY_gate_share_parameter(UINT target_index,
+        const ParameterId& parameter_id, double parameter_coef = 1.);
+    virtual void add_parametric_RZ_gate_new_parameter(UINT target_index,
+        const ParameterId& parameter_id, double initial_parameter,
+        double parameter_coef = 1.);
+    virtual void add_parametric_RZ_gate_share_parameter(UINT target_index,
+        const ParameterId& parameter_id, double parameter_coef = 1.);
+    virtual void add_parametric_multi_Pauli_rotation_gate_new_parameter(
+        std::vector<UINT> target, std::vector<UINT> pauli_id,
+        const ParameterId& parameter_id, double initial_parameter,
+        double parameter_coef = 1.);
+    virtual void add_parametric_multi_Pauli_rotation_gate_share_parameter(
+        std::vector<UINT> target, std::vector<UINT> pauli_id,
+        const ParameterId& parameter_id, double parameter_coef = 1.);
+    virtual std::vector<double> backprop(GeneralQuantumOperator* obs);
+    virtual std::vector<double> backprop_inner_product(QuantumState* bistate);
+
+    // 互換性のために残す旧メソッド(パラメータのIDとして整数値を利用)
+    virtual double get_parameter(UINT index) const;
+    virtual void set_parameter(UINT index, double value);
     virtual void add_parametric_RX_gate(
         UINT target_index, double initial_angle);
     virtual void add_parametric_RY_gate(
@@ -59,6 +101,5 @@ public:
     virtual void add_parametric_multi_Pauli_rotation_gate(
         std::vector<UINT> target, std::vector<UINT> pauli_id,
         double initial_angle);
-    virtual std::vector<double> backprop(GeneralQuantumOperator* obs);
-    virtual std::vector<double> backprop_inner_product(QuantumState* bistate);
+    virtual UINT get_parameter_count() const;
 };

--- a/src/vqcsim/parametric_gate.hpp
+++ b/src/vqcsim/parametric_gate.hpp
@@ -1,4 +1,3 @@
-
 #pragma once
 
 #include <cppsim/exception.hpp>
@@ -13,18 +12,37 @@
 #include <gpusim/update_ops_cuda.h>
 #endif
 
+#include "parameter.hpp"
+
 class QuantumGate_SingleParameter : public QuantumGateBase {
 protected:
-    double _angle;
-    UINT _parameter_type;
+    ParameterKey _parameter_key;
+    double _parameter_coef;
 
 public:
-    QuantumGate_SingleParameter(double angle) : _angle(angle) {
+    QuantumGate_SingleParameter(
+        const ParameterKey& parameter_key, double parameter_coef = 1.)
+        : _parameter_key(parameter_key), _parameter_coef(parameter_coef) {
         _gate_property |= FLAG_PARAMETRIC;
-        _parameter_type = 0;
     }
-    virtual void set_parameter_value(double value) { _angle = value; }
-    virtual double get_parameter_value() const { return _angle; }
+    ParameterKey get_parameter_key() { return _parameter_key; }
+    ParameterId get_parameter_id() {
+        return parameter::get_parameter_id(_parameter_key);
+    }
+    double get_parameter_coef() { return _parameter_coef; }
+    void set_parameter_value(
+        double parameter, ParameterSet& parameter_set) const {
+        parameter::set_parameter_value(
+            _parameter_key, parameter / _parameter_coef, parameter_set);
+    }
+    void set_parameter_value(double parameter) const {
+        parameter::set_parameter_value(
+            _parameter_key, parameter / _parameter_coef);
+    }
+    double get_parameter_value(const ParameterSet& parameter_set = {}) const {
+        return parameter::get_parameter_value(_parameter_key, parameter_set) *
+               _parameter_coef;
+    }
     virtual QuantumGate_SingleParameter* copy() const override = 0;
 };
 
@@ -37,11 +55,13 @@ protected:
     T_UPDATE_FUNC* _update_func_dm = NULL;
     T_GPU_UPDATE_FUNC* _update_func_gpu = NULL;
 
-    QuantumGate_SingleParameterOneQubitRotation(double angle)
-        : QuantumGate_SingleParameter(angle) {}
-
 public:
-    virtual void update_quantum_state(QuantumStateBase* state) override {
+    QuantumGate_SingleParameterOneQubitRotation(
+        const ParameterKey& parameter_key, double parameter_coef = 1.)
+        : QuantumGate_SingleParameter(parameter_key, parameter_coef) {}
+    virtual void update_quantum_state(
+        QuantumStateBase* state, const ParameterSet& parameter_set) {
+        double angle = this->get_parameter_value(parameter_set);
         if (state->is_state_vector()) {
 #ifdef _USE_GPU
             if (state->get_device_name() == "gpu") {
@@ -52,7 +72,7 @@ public:
                         "quantum_state(QuantumStateBase) : update function is "
                         "undefined");
                 }
-                _update_func_gpu(this->_target_qubit_list[0].index(), _angle,
+                _update_func_gpu(this->_target_qubit_list[0].index(), angle,
                     state->data(), state->dim, state->get_cuda_stream(),
                     state->device_number);
                 return;
@@ -65,7 +85,7 @@ public:
                     "quantum_state(QuantumStateBase) : update function is "
                     "undefined");
             }
-            _update_func(this->_target_qubit_list[0].index(), _angle,
+            _update_func(this->_target_qubit_list[0].index(), angle,
                 state->data_c(), state->dim);
         } else {
             if (_update_func_dm == NULL) {
@@ -75,16 +95,21 @@ public:
                     "quantum_state(QuantumStateBase) : update function is "
                     "undefined");
             }
-            _update_func_dm(this->_target_qubit_list[0].index(), _angle,
+            _update_func_dm(this->_target_qubit_list[0].index(), angle,
                 state->data_c(), state->dim);
         }
+    }
+    virtual void update_quantum_state(QuantumStateBase* state) {
+        update_quantum_state(state, {});
     }
 };
 
 class ClsParametricRXGate : public QuantumGate_SingleParameterOneQubitRotation {
 public:
-    ClsParametricRXGate(UINT target_qubit_index, double angle)
-        : QuantumGate_SingleParameterOneQubitRotation(angle) {
+    ClsParametricRXGate(UINT target_qubit_index,
+        const ParameterKey& parameter_key, double parameter_coef = 1.)
+        : QuantumGate_SingleParameterOneQubitRotation(
+              parameter_key, parameter_coef) {
         this->_name = "ParametricRX";
         this->_update_func = RX_gate;
         this->_update_func_dm = dm_RX_gate;
@@ -94,10 +119,15 @@ public:
         this->_target_qubit_list.push_back(
             TargetQubitInfo(target_qubit_index, FLAG_X_COMMUTE));
     }
-    virtual void set_matrix(ComplexMatrix& matrix) const override {
+    virtual void set_matrix(
+        ComplexMatrix& matrix, const ParameterSet& parameter_set) const {
+        double angle = this->get_parameter_value(parameter_set);
         matrix = ComplexMatrix::Zero(2, 2);
-        matrix << cos(_angle / 2), sin(_angle / 2) * 1.i, sin(_angle / 2) * 1.i,
-            cos(_angle / 2);
+        matrix << cos(angle / 2), sin(angle / 2) * 1.i, sin(angle / 2) * 1.i,
+            cos(angle / 2);
+    }
+    virtual void set_matrix(ComplexMatrix& matrix) const {
+        set_matrix(matrix, {});
     }
     virtual QuantumGate_SingleParameter* copy() const override {
         return new ClsParametricRXGate(*this);
@@ -106,8 +136,10 @@ public:
 
 class ClsParametricRYGate : public QuantumGate_SingleParameterOneQubitRotation {
 public:
-    ClsParametricRYGate(UINT target_qubit_index, double angle)
-        : QuantumGate_SingleParameterOneQubitRotation(angle) {
+    ClsParametricRYGate(UINT target_qubit_index,
+        const ParameterKey& parameter_key, double parameter_coef = 1.)
+        : QuantumGate_SingleParameterOneQubitRotation(
+              parameter_key, parameter_coef) {
         this->_name = "ParametricRY";
         this->_update_func = RY_gate;
         this->_update_func_dm = dm_RY_gate;
@@ -117,10 +149,15 @@ public:
         this->_target_qubit_list.push_back(
             TargetQubitInfo(target_qubit_index, FLAG_Y_COMMUTE));
     }
-    virtual void set_matrix(ComplexMatrix& matrix) const override {
+    virtual void set_matrix(
+        ComplexMatrix& matrix, const ParameterSet& parameter_set) const {
+        double angle = this->get_parameter_value(parameter_set);
         matrix = ComplexMatrix::Zero(2, 2);
-        matrix << cos(_angle / 2), sin(_angle / 2), -sin(_angle / 2),
-            cos(_angle / 2);
+        matrix << cos(angle / 2), sin(angle / 2), -sin(angle / 2),
+            cos(angle / 2);
+    }
+    virtual void set_matrix(ComplexMatrix& matrix) const {
+        set_matrix(matrix, {});
     }
     virtual QuantumGate_SingleParameter* copy() const override {
         return new ClsParametricRYGate(*this);
@@ -129,8 +166,10 @@ public:
 
 class ClsParametricRZGate : public QuantumGate_SingleParameterOneQubitRotation {
 public:
-    ClsParametricRZGate(UINT target_qubit_index, double angle)
-        : QuantumGate_SingleParameterOneQubitRotation(angle) {
+    ClsParametricRZGate(UINT target_qubit_index,
+        const ParameterKey& parameter_key, double parameter_coef = 1.)
+        : QuantumGate_SingleParameterOneQubitRotation(
+              parameter_key, parameter_coef) {
         this->_name = "ParametricRZ";
         this->_update_func = RZ_gate;
         this->_update_func_dm = dm_RZ_gate;
@@ -140,10 +179,15 @@ public:
         this->_target_qubit_list.push_back(
             TargetQubitInfo(target_qubit_index, FLAG_Z_COMMUTE));
     }
-    virtual void set_matrix(ComplexMatrix& matrix) const override {
+    virtual void set_matrix(
+        ComplexMatrix& matrix, const ParameterSet& parameter_set) const {
+        double angle = this->get_parameter_value(parameter_set);
         matrix = ComplexMatrix::Zero(2, 2);
-        matrix << cos(_angle / 2) + 1.i * sin(_angle / 2), 0, 0,
-            cos(_angle / 2) - 1.i * sin(_angle / 2);
+        matrix << cos(angle / 2) + 1.i * sin(angle / 2), 0, 0,
+            cos(angle / 2) - 1.i * sin(angle / 2);
+    }
+    virtual void set_matrix(ComplexMatrix& matrix) const {
+        set_matrix(matrix, {});
     }
     virtual QuantumGate_SingleParameter* copy() const override {
         return new ClsParametricRZGate(*this);
@@ -155,8 +199,9 @@ protected:
     PauliOperator* _pauli;
 
 public:
-    ClsParametricPauliRotationGate(double angle, PauliOperator* pauli)
-        : QuantumGate_SingleParameter(angle) {
+    ClsParametricPauliRotationGate(PauliOperator* pauli,
+        const ParameterKey& parameter_key, double parameter_coef = 1.)
+        : QuantumGate_SingleParameter(parameter_key, parameter_coef) {
         _pauli = pauli;
         this->_name = "ParametricPauliRotation";
         auto target_index_list = _pauli->get_index_list();
@@ -172,45 +217,56 @@ public:
             this->_target_qubit_list.push_back(TargetQubitInfo(
                 target_index_list[index], commutation_relation));
         }
-    };
+    }
     virtual ~ClsParametricPauliRotationGate() { delete _pauli; }
-    virtual void update_quantum_state(QuantumStateBase* state) override {
+    virtual void update_quantum_state(
+        QuantumStateBase* state, const ParameterSet& parameter_set) {
         auto target_index_list = _pauli->get_index_list();
         auto pauli_id_list = _pauli->get_pauli_id_list();
+        double angle = this->get_parameter_value(parameter_set);
         if (state->is_state_vector()) {
 #ifdef _USE_GPU
             if (state->get_device_name() == "gpu") {
                 multi_qubit_Pauli_rotation_gate_partial_list_host(
                     target_index_list.data(), pauli_id_list.data(),
-                    (UINT)target_index_list.size(), _angle, state->data(),
+                    (UINT)target_index_list.size(), angle, state->data(),
                     state->dim, state->get_cuda_stream(), state->device_number);
             } else {
                 multi_qubit_Pauli_rotation_gate_partial_list(
                     target_index_list.data(), pauli_id_list.data(),
-                    (UINT)target_index_list.size(), _angle, state->data_c(),
+                    (UINT)target_index_list.size(), angle, state->data_c(),
                     state->dim);
             }
 #else
             multi_qubit_Pauli_rotation_gate_partial_list(
                 target_index_list.data(), pauli_id_list.data(),
-                (UINT)target_index_list.size(), _angle, state->data_c(),
+                (UINT)target_index_list.size(), angle, state->data_c(),
                 state->dim);
 #endif
         } else {
             dm_multi_qubit_Pauli_rotation_gate_partial_list(
                 target_index_list.data(), pauli_id_list.data(),
-                (UINT)target_index_list.size(), _angle, state->data_c(),
+                (UINT)target_index_list.size(), angle, state->data_c(),
                 state->dim);
         }
     };
+    virtual void update_quantum_state(QuantumStateBase* state) {
+        update_quantum_state(state, {});
+    }
     virtual QuantumGate_SingleParameter* copy() const override {
-        return new ClsParametricPauliRotationGate(_angle, _pauli->copy());
+        return new ClsParametricPauliRotationGate(
+            _pauli->copy(), _parameter_key);
     };
-    virtual void set_matrix(ComplexMatrix& matrix) const override {
+    virtual void set_matrix(
+        ComplexMatrix& matrix, const ParameterSet& parameter_set) const {
+        double angle = this->get_parameter_value(parameter_set);
         get_Pauli_matrix(matrix, _pauli->get_pauli_id_list());
-        matrix = cos(_angle / 2) *
+        matrix = cos(angle / 2) *
                      ComplexMatrix::Identity(matrix.rows(), matrix.cols()) +
-                 1.i * sin(_angle / 2) * matrix;
+                 1.i * sin(angle / 2) * matrix;
     };
+    virtual void set_matrix(ComplexMatrix& matrix) const {
+        set_matrix(matrix, {});
+    }
     virtual PauliOperator* get_pauli() const { return _pauli; };
 };

--- a/src/vqcsim/parametric_gate.hpp
+++ b/src/vqcsim/parametric_gate.hpp
@@ -130,7 +130,13 @@ public:
         set_matrix(matrix, {});
     }
     virtual QuantumGate_SingleParameter* copy() const override {
-        return new ClsParametricRXGate(*this);
+        auto* copied_gate = new ClsParametricRXGate(*this);
+        ParameterKey key = this->_parameter_key;
+        if (parameter::get_parameter_type(key) == "global") {
+            copied_gate->_parameter_key = parameter::create_parameter(
+                parameter::get_parameter_value(key, {}));
+        }
+        return copied_gate;
     };
 };
 
@@ -160,7 +166,13 @@ public:
         set_matrix(matrix, {});
     }
     virtual QuantumGate_SingleParameter* copy() const override {
-        return new ClsParametricRYGate(*this);
+        auto* copied_gate = new ClsParametricRYGate(*this);
+        ParameterKey key = this->_parameter_key;
+        if (parameter::get_parameter_type(key) == "global") {
+            copied_gate->_parameter_key = parameter::create_parameter(
+                parameter::get_parameter_value(key, {}));
+        }
+        return copied_gate;
     };
 };
 
@@ -190,7 +202,13 @@ public:
         set_matrix(matrix, {});
     }
     virtual QuantumGate_SingleParameter* copy() const override {
-        return new ClsParametricRZGate(*this);
+        auto* copied_gate = new ClsParametricRZGate(*this);
+        ParameterKey key = this->_parameter_key;
+        if (parameter::get_parameter_type(key) == "global") {
+            copied_gate->_parameter_key = parameter::create_parameter(
+                parameter::get_parameter_value(key, {}));
+        }
+        return copied_gate;
     };
 };
 
@@ -254,8 +272,14 @@ public:
         update_quantum_state(state, {});
     }
     virtual QuantumGate_SingleParameter* copy() const override {
-        return new ClsParametricPauliRotationGate(
-            _pauli->copy(), _parameter_key);
+        auto* copied_gate =
+            new ClsParametricPauliRotationGate(_pauli->copy(), _parameter_key);
+        ParameterKey key = this->_parameter_key;
+        if (parameter::get_parameter_type(key) == "global") {
+            copied_gate->_parameter_key = parameter::create_parameter(
+                parameter::get_parameter_value(key, {}));
+        }
+        return copied_gate;
     };
     virtual void set_matrix(
         ComplexMatrix& matrix, const ParameterSet& parameter_set) const {

--- a/src/vqcsim/parametric_gate_factory.cpp
+++ b/src/vqcsim/parametric_gate_factory.cpp
@@ -15,20 +15,24 @@
 #include "parametric_gate.hpp"
 
 namespace gate {
-QuantumGate_SingleParameter* ParametricRX(
-    UINT target_qubit_index, double initial_angle) {
-    return new ClsParametricRXGate(target_qubit_index, initial_angle);
+QuantumGate_SingleParameter* ParametricRX(UINT target_qubit_index,
+    const ParameterKey& parameter_id, double parameter_coef) {
+    return new ClsParametricRXGate(
+        target_qubit_index, parameter_id, parameter_coef);
 }
-QuantumGate_SingleParameter* ParametricRY(
-    UINT target_qubit_index, double initial_angle) {
-    return new ClsParametricRYGate(target_qubit_index, initial_angle);
+QuantumGate_SingleParameter* ParametricRY(UINT target_qubit_index,
+    const ParameterKey& parameter_id, double parameter_coef) {
+    return new ClsParametricRYGate(
+        target_qubit_index, parameter_id, parameter_coef);
 }
-QuantumGate_SingleParameter* ParametricRZ(
-    UINT target_qubit_index, double initial_angle) {
-    return new ClsParametricRZGate(target_qubit_index, initial_angle);
+QuantumGate_SingleParameter* ParametricRZ(UINT target_qubit_index,
+    const ParameterKey& parameter_id, double parameter_coef) {
+    return new ClsParametricRZGate(
+        target_qubit_index, parameter_id, parameter_coef);
 }
 QuantumGate_SingleParameter* ParametricPauliRotation(std::vector<UINT> target,
-    std::vector<UINT> pauli_id, double initial_angle) {
+    std::vector<UINT> pauli_id, const ParameterKey& parameter_id,
+    double parameter_coef) {
     if (!check_is_unique_index_list(target)) {
         throw DuplicatedQubitIndexException(
             "Error: gate::ParametricPauliRotation(std::vector<UINT>, "
@@ -37,12 +41,13 @@ QuantumGate_SingleParameter* ParametricPauliRotation(std::vector<UINT> target,
             "\nInfo: NULL used to be returned, "
             "but it changed to throw exception.");
     }
-    auto pauli = new PauliOperator(target, pauli_id, initial_angle);
-    return new ClsParametricPauliRotationGate(initial_angle, pauli);
+    auto pauli = new PauliOperator(target, pauli_id, 0.);
+    return new ClsParametricPauliRotationGate(
+        pauli, parameter_id, parameter_coef);
 }
 
 QuantumGateBase* create_parametric_quantum_gate_from_string(
-    std::string gate_string) {
+    std::string gate_string, const ParameterKey& parameter_id) {
     auto non_parametric_gate =
         gate::create_quantum_gate_from_string(gate_string);
     if (non_parametric_gate != NULL) return non_parametric_gate;
@@ -60,13 +65,13 @@ QuantumGateBase* create_parametric_quantum_gate_from_string(
 
     if (strcasecmp(sbuf, "PRX") == 0) {
         unsigned int target = atoi(strtok(NULL, delim));
-        gate = gate::ParametricRX(target);
+        gate = gate::ParametricRX(target, parameter_id);
     } else if (strcasecmp(sbuf, "PRY") == 0) {
         unsigned int target = atoi(strtok(NULL, delim));
-        gate = gate::ParametricRY(target);
+        gate = gate::ParametricRY(target, parameter_id);
     } else if (strcasecmp(sbuf, "PRZ") == 0) {
         unsigned int target = atoi(strtok(NULL, delim));
-        gate = gate::ParametricRZ(target);
+        gate = gate::ParametricRZ(target, parameter_id);
     } else if (strcasecmp(sbuf, "PPR") == 0) {
         char* pauliStr = strtok(NULL, delim);
         unsigned int targetCount = (UINT)strlen(pauliStr);
@@ -85,10 +90,37 @@ QuantumGateBase* create_parametric_quantum_gate_from_string(
         for (unsigned int i = 0; i < targetCount; i++) {
             targets[i] = atoi(strtok(NULL, delim));
         }
-        gate = gate::ParametricPauliRotation(targets, pauli);
+        gate = gate::ParametricPauliRotation(targets, pauli, parameter_id);
     }
     free(buf);
     return gate;
+}
+
+QuantumGateBase* create_parametric_quantum_gate_from_string(
+    std::string gate_string, double initial_angle) {
+    return create_parametric_quantum_gate_from_string(
+        gate_string, parameter::create_parameter(initial_angle));
+}
+QuantumGate_SingleParameter* ParametricRX(
+    UINT qubit_index, double initial_angle) {
+    return ParametricRX(
+        qubit_index, parameter::create_parameter(initial_angle));
+}
+QuantumGate_SingleParameter* ParametricRY(
+    UINT qubit_index, double initial_angle) {
+    return ParametricRY(
+        qubit_index, parameter::create_parameter(initial_angle));
+}
+QuantumGate_SingleParameter* ParametricRZ(
+    UINT qubit_index, double initial_angle) {
+    return ParametricRZ(
+        qubit_index, parameter::create_parameter(initial_angle));
+}
+DllExport QuantumGate_SingleParameter* ParametricPauliRotation(
+    std::vector<UINT> target, std::vector<UINT> pauli_id,
+    double initial_angle) {
+    return ParametricPauliRotation(
+        target, pauli_id, parameter::create_parameter(initial_angle));
 }
 
 }  // namespace gate

--- a/src/vqcsim/parametric_gate_factory.hpp
+++ b/src/vqcsim/parametric_gate_factory.hpp
@@ -8,7 +8,20 @@
 
 namespace gate {
 DllExport QuantumGateBase* create_parametric_quantum_gate_from_string(
-    std::string gate_string);
+    std::string gate_string, const ParameterKey& parameter_id);
+DllExport QuantumGate_SingleParameter* ParametricRX(UINT qubit_index,
+    const ParameterKey& parameter_id, double parameter_coef = 1.);
+DllExport QuantumGate_SingleParameter* ParametricRY(UINT qubit_index,
+    const ParameterKey& parameter_id, double parameter_coef = 1.);
+DllExport QuantumGate_SingleParameter* ParametricRZ(UINT qubit_index,
+    const ParameterKey& parameter_id, double parameter_coef = 1.);
+DllExport QuantumGate_SingleParameter* ParametricPauliRotation(
+    std::vector<UINT> target, std::vector<UINT> pauli_id,
+    const ParameterKey& parameter_id, double parameter_coef = 1.);
+
+// old methods
+DllExport QuantumGateBase* create_parametric_quantum_gate_from_string(
+    std::string gate_string, double initial_angle = 0.);
 DllExport QuantumGate_SingleParameter* ParametricRX(
     UINT qubit_index, double initial_angle = 0.);
 DllExport QuantumGate_SingleParameter* ParametricRY(

--- a/src/vqcsim/parametric_simulator.hpp
+++ b/src/vqcsim/parametric_simulator.hpp
@@ -11,8 +11,11 @@ public:
     ParametricQuantumCircuitSimulator(
         ParametricQuantumCircuit* circuit, QuantumStateBase* state = NULL);
     double get_parameter(UINT index) const;
+    double get_parameter(const ParameterId& parameter_id) const;
     void add_parameter_value(UINT index, double value);
+    void add_parameter_value(const ParameterId& parameter_id, double value);
     void set_parameter_value(UINT index, double value);
+    void set_parameter_value(const ParameterId& parameter_id, double value);
     UINT get_parametric_gate_count();
     UINT get_parametric_gate_position(UINT index);
 };

--- a/src/vqcsim/simulator_parametric.cpp
+++ b/src/vqcsim/simulator_parametric.cpp
@@ -8,17 +8,30 @@ ParametricQuantumCircuitSimulator::ParametricQuantumCircuitSimulator(
 double ParametricQuantumCircuitSimulator::get_parameter(UINT index) const {
     return _parametric_circuit->get_parameter(index);
 }
+double ParametricQuantumCircuitSimulator::get_parameter(
+    const ParameterId& parameter_id) const {
+    return _parametric_circuit->get_parameter(parameter_id);
+}
 void ParametricQuantumCircuitSimulator::add_parameter_value(
     UINT index, double value) {
     _parametric_circuit->set_parameter(
         index, _parametric_circuit->get_parameter(index) + value);
 }
+void ParametricQuantumCircuitSimulator::add_parameter_value(
+    const ParameterId& parameter_id, double value) {
+    _parametric_circuit->set_parameter(
+        parameter_id, _parametric_circuit->get_parameter(parameter_id) + value);
+}
 void ParametricQuantumCircuitSimulator::set_parameter_value(
     UINT index, double value) {
     _parametric_circuit->set_parameter(index, value);
 }
+void ParametricQuantumCircuitSimulator::set_parameter_value(
+    const ParameterId& parameter_id, double value) {
+    _parametric_circuit->set_parameter(parameter_id, value);
+}
 UINT ParametricQuantumCircuitSimulator::get_parametric_gate_count() {
-    return _parametric_circuit->get_parameter_count();
+    return _parametric_circuit->get_parametric_gate_count();
 }
 UINT ParametricQuantumCircuitSimulator::get_parametric_gate_position(
     UINT index) {


### PR DESCRIPTION
これは1つ目の方法、gate factoryを使ったりコンストラクタを直接読んだときのパラメータ保管場所をparameter名前空間のグローバルに配置するプランです。